### PR TITLE
docs: 修复文档中的 GitHub URL——从 fork 改为上游仓库

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ are very welcome.
 ## Quick Start
 
 ```bash
-git clone https://github.com/kinsomwang/ScratchV
+git clone https://github.com/ScratchV-Compiler/ScratchV
 cd ScratchV
 pip install -e .            # install in editable mode
 pip install tinyfive        # optional: assembly verification

--- a/docs/00-环境搭建指南.md
+++ b/docs/00-环境搭建指南.md
@@ -59,7 +59,7 @@ mkdir -p ~/workspace
 cd ~/workspace
 
 # 克隆 ScratchV 仓库
-git clone https://github.com/kinsomwang/ScratchV.git
+git clone https://github.com/ScratchV-Compiler/ScratchV.git
 cd ScratchV
 ```
 
@@ -258,7 +258,7 @@ pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 
 跳到 [04-故障排除FAQ.md](04-故障排除FAQ.md) 查找常见问题的解决方案。
 
-如果还是解决不了，欢迎到 [GitHub Issues](https://github.com/kinsomwang/ScratchV/issues) 提问。
+如果还是解决不了，欢迎到 [GitHub Issues](https://github.com/ScratchV-Compiler/ScratchV/issues) 提问。
 
 ---
 

--- a/docs/04-故障排除FAQ.md
+++ b/docs/04-故障排除FAQ.md
@@ -297,7 +297,7 @@ git config --global http.proxy http://127.0.0.1:7890
 git config --global https.proxy http://127.0.0.1:7890
 
 # 或者用浅克隆（只取最近一次提交）
-git clone --depth 1 https://github.com/kinsomwang/ScratchV.git
+git clone --depth 1 https://github.com/ScratchV-Compiler/ScratchV.git
 ```
 
 ---
@@ -341,7 +341,7 @@ ScratchV 的编译速度通常不是瓶颈（CNN 模型几秒就能编译完）�
 
 ## 还没解决？
 
-1. 搜索 [GitHub Issues](https://github.com/kinsomwang/ScratchV/issues) — 看有没有人遇到过同样的问题
+1. 搜索 [GitHub Issues](https://github.com/ScratchV-Compiler/ScratchV/issues) — 看有没有人遇到过同样的问题
 2. 如果没找到，创建新的 Issue，附上：
    - 你的操作系统和 Python 版本
    - 完整的错误信息（复制粘贴，不要截图）

--- a/docs/topics/html/00-环境搭建指南.html
+++ b/docs/topics/html/00-环境搭建指南.html
@@ -515,7 +515,7 @@ mkdir<span class="w"> </span>-p<span class="w"> </span>~/workspace
 <span class="nb">cd</span><span class="w"> </span>~/workspace
 
 <span class="c1"># 克隆 ScratchV 仓库</span>
-git<span class="w"> </span>clone<span class="w"> </span>https://github.com/kinsomwang/ScratchV.git
+git<span class="w"> </span>clone<span class="w"> </span>https://github.com/ScratchV-Compiler/ScratchV.git
 <span class="nb">cd</span><span class="w"> </span>ScratchV
 </code></pre></div>
 
@@ -698,7 +698,7 @@ pip<span class="w"> </span>config<span class="w"> </span><span class="nb">set</s
 <hr />
 <h2>遇到问题？
 <p>跳到 <a href="04-故障排除-FAQ.html">04-故障排除FAQ</a> 查找常见问题的解决方案。</p>
-<p>如果还是解决不了，欢迎到 <a href="https://github.com/kinsomwang/ScratchV/issues" target="_blank" rel="noopener">GitHub Issues</a> 提问。</p>
+<p>如果还是解决不了，欢迎到 <a href="https://github.com/ScratchV-Compiler/ScratchV/issues" target="_blank" rel="noopener">GitHub Issues</a> 提问。</p>
 <hr />
 <blockquote>
 <p><strong>下一步</strong>: 环境搭好了，去看看 <a href="01-编译器概念入门.html">01-编译器概念入门</a>，理解编译器到底在做什么。</p>

--- a/docs/topics/html/04-故障排除-FAQ.html
+++ b/docs/topics/html/04-故障排除-FAQ.html
@@ -714,7 +714,7 @@ git<span class="w"> </span>config<span class="w"> </span>--global<span class="w"
 git<span class="w"> </span>config<span class="w"> </span>--global<span class="w"> </span>https.proxy<span class="w"> </span>http://127.0.0.1:7890
 
 <span class="c1"># 或者用浅克隆（只取最近一次提交）</span>
-git<span class="w"> </span>clone<span class="w"> </span>--depth<span class="w"> </span><span class="m">1</span><span class="w"> </span>https://github.com/kinsomwang/ScratchV.git
+git<span class="w"> </span>clone<span class="w"> </span>--depth<span class="w"> </span><span class="m">1</span><span class="w"> </span>https://github.com/ScratchV-Compiler/ScratchV.git
 </code></pre></div>
 
 <hr />
@@ -746,7 +746,7 @@ git<span class="w"> </span>clone<span class="w"> </span>--depth<span class="w"> 
 <hr />
 <h2>还没解决？
 <ol>
-<li>搜索 <a href="https://github.com/kinsomwang/ScratchV/issues" target="_blank" rel="noopener">GitHub Issues</a> — 看有没有人遇到过同样的问题</li>
+<li>搜索 <a href="https://github.com/ScratchV-Compiler/ScratchV/issues" target="_blank" rel="noopener">GitHub Issues</a> — 看有没有人遇到过同样的问题</li>
 <li>如果没找到，创建新的 Issue，附上：</li>
 <li>你的操作系统和 Python 版本</li>
 <li>完整的错误信息（复制粘贴，不要截图）</li>

--- a/scratchv_dag/README.md
+++ b/scratchv_dag/README.md
@@ -2,7 +2,7 @@
 
 **scratchv_dag** is a standalone Python package providing DAG-based instruction selection infrastructure inspired by LLVM's SelectionDAG, paired with a 4 MB L1 cache simulator and a buddy-system memory allocator designed for edge-NPU compiler toolchains.
 
-It operates independently or as part of the [ScratchV](https://github.com/kinsomwang/ScratchV) ONNX→RISC-V compiler.
+It operates independently or as part of the [ScratchV](https://github.com/ScratchV-Compiler/ScratchV) ONNX→RISC-V compiler.
 
 ---
 


### PR DESCRIPTION
所有文档中的 github.com/kinsomwang/ScratchV 改为 github.com/ScratchV-Compiler/ScratchV， 涉及 6 个文件（3 个 .md + 2 个 .html + 1 个 CONTRIBUTING.md）。