### PR TITLE
[FIX] RA: register allocator spill/reload closed loop via linear scan

### DIFF
--- a/scratchv/backend/regalloc_linear.py
+++ b/scratchv/backend/regalloc_linear.py
@@ -192,10 +192,15 @@ class LinearScanAllocator:
         )
         self.stack_slot: int = 0
         self.alloc_map: dict[str, str] = {}
-        self.spill_code: list[tuple[int, str, str]] = (
-            []  # (position, op, operand)
-        )
+        self.spill_code: dict[int, list[str]] = {}  # pos -> [sw asm lines]
         self._spill_slots: dict[str, int] = {}  # vreg -> slot offset
+        self._reloads: dict[int, list[tuple[str, int]]] = (
+            {}  # pos -> [(vreg, slot), ...]
+        )
+        self._spilled: set[str] = set()
+        self._intervals: list[LiveInterval] = []
+        self._vreg_interval: dict[str, LiveInterval] = {}
+        self._evictions: dict[int, list[str]] = {}  # pos -> sw lines emitted before reload
 
     # ------------------------------------------------------------------
     # Live interval computation
@@ -273,6 +278,11 @@ class LinearScanAllocator:
         self.alloc_map.clear()
         self.spill_code.clear()
         self._spill_slots.clear()
+        self._reloads.clear()
+        self._spilled.clear()
+        self._evictions.clear()
+        self._intervals = intervals
+        self._vreg_interval = {iv.vreg: iv for iv in intervals}
 
         # Active list: (interval, phys_reg) sorted by increasing end
         active: list[tuple[LiveInterval, str]] = []
@@ -320,19 +330,12 @@ class LinearScanAllocator:
         """Select a register to spill and emit spill code.
 
         Chooses the active interval with the farthest end position to spill.
-
-        Parameters
-        ----------
-        current:
-            The live interval that needs a register.
-        active:
-            Currently active intervals.
-        free_regs:
-            List of free registers (will be appended to if a spill succeeds).
+        Records reload positions for the spilled interval so that
+        ``get_allocated_code`` can insert ``lw`` before each future use.
 
         Returns
         -------
-        The physical register freed by spilling, or None if no spill possible.
+        The physical register freed by spilling, or None if current is spilled.
         """
         if not active:
             return None
@@ -350,23 +353,37 @@ class LinearScanAllocator:
 
         # Only spill if the current interval ends earlier
         if current.end <= spill_interval.end:
-            # Spill the farthest interval
+            # Spill the farthest active interval (victim)
             slot = self._get_spill_slot(spill_interval.vreg)
             active.pop(spill_idx)
-            # Emit store after the definition point
-            self.spill_code.append(
-                (spill_interval.start, "sw",
-                 f"{spill_reg}, {slot}(sp)  # spill {spill_interval.vreg}")
+            self._evictions.setdefault(current.start, []).append(
+                f"  sw {spill_reg}, {slot}(sp)  # evict {spill_interval.vreg}"
             )
+            # Remove stale mapping so codegen won't use the freed register
+            if spill_interval.vreg in self.alloc_map:
+                del self.alloc_map[spill_interval.vreg]
+            self._spilled.add(spill_interval.vreg)
+            # Record reload at every future use of the spilled vreg
+            for use_pos in spill_interval.uses:
+                if use_pos > current.start:
+                    self._reloads.setdefault(use_pos, []).append(
+                        (spill_interval.vreg, slot))
             free_regs.append(spill_reg)
             return spill_reg
 
         # Otherwise, spill the current interval
         slot = self._get_spill_slot(current.vreg)
-        self.spill_code.append(
-            (current.start, "sw",
-             f"{self.phys_regs[0]}, {slot}(sp)  # spill {current.vreg}")
+        # Assign a temporary register for the definition instruction
+        temp_reg = self.phys_regs[0]
+        self.alloc_map[current.vreg] = temp_reg
+        self._spilled.add(current.vreg)
+        self.spill_code.setdefault(current.start, []).append(
+            f"  sw {temp_reg}, {slot}(sp)  # spill {current.vreg}"
         )
+        for use_pos in current.uses:
+            if use_pos > current.start:
+                self._reloads.setdefault(use_pos, []).append(
+                    (current.vreg, slot))
         return None
 
     def _get_spill_slot(self, vreg: str) -> int:
@@ -380,40 +397,127 @@ class LinearScanAllocator:
     # Code generation
     # ------------------------------------------------------------------
 
+    def emit(self, block: list[LsInstruction]) -> str:
+        """Main entry point: allocate registers and emit assembly.
+
+        Computes live intervals, runs linear-scan allocation, then
+        generates assembly with spill stores and reloads interleaved.
+        """
+        intervals = self.compute_live_intervals(block)
+        self.allocate(intervals)
+        return self.get_allocated_code(block)
+
     def get_allocated_code(self, block: list[LsInstruction]) -> str:
-        """Generate allocated assembly code for the block.
+        """Generate allocated assembly with spill stores and reloads.
 
-        Parameters
-        ----------
-        block:
-            The original block of LsInstruction objects.
-
-        Returns
-        -------
-        RISC-V assembly text with physical registers and spill code.
+        Walks the instruction block in order.  Before each instruction
+        that uses a spilled vreg, a reload ``lw`` is inserted.  After
+        each instruction that defines a spilled vreg, a spill ``sw``
+        is inserted.
         """
         lines: list[str] = []
-        rename = self.alloc_map
-
-        # Build a position -> spill load map
-        spill_loads: dict[int, list[str]] = {}
-        for pos, op, operand in self.spill_code:
-            if "sw" in op:
-                lines.append(f"  {op} {operand}")
-            else:
-                if pos not in spill_loads:
-                    spill_loads[pos] = []
-                spill_loads[pos].append(f"  {op} {operand}")
+        rename: dict[str, str] = dict(self.alloc_map)
 
         for inst in block:
-            # Insert spill loads before instruction
-            if inst.id in spill_loads:
-                for load_line in spill_loads[inst.id]:
-                    lines.append(load_line)
+            # Emit eviction spill stores before reloads at this position
+            if inst.id in self._evictions:
+                lines.extend(self._evictions[inst.id])
+
+            # Insert reloads before the instruction
+            if inst.id in self._reloads:
+                # Vregs used/defined by this instruction must not be evicted
+                # by _evict_for_reload, otherwise inst.to_asm() would get
+                # an unresolved vreg name.
+                protected: set[str] = inst.uses | inst.defines
+                for vreg, slot in self._reloads[inst.id]:
+                    reload_reg = self._pick_reload_reg(rename, inst.id, protected)
+                    lines.append(
+                        f"  lw {reload_reg}, {slot}(sp)"
+                        f"  # reload {vreg}"
+                    )
+                    rename[vreg] = reload_reg
 
             lines.append(inst.to_asm(rename))
 
+            # Insert spill stores after the instruction
+            if inst.id in self.spill_code:
+                lines.extend(self.spill_code[inst.id])
+
         return "\n".join(lines)
+
+    def _pick_reload_reg(self, rename: dict[str, str], current_pos: int,
+                          protected_vregs: set[str] | None = None) -> str:
+        """Pick a free physical register for a reload ``lw``.
+
+        Filters *rename* by actual liveness at *current_pos* so that
+        registers held by already-expired vregs are considered free.
+        If all registers are genuinely occupied, evicts the one whose
+        interval ends farthest away.
+
+        *protected_vregs* are excluded from eviction — typically the
+        current instruction's own uses/defines — since evicting them
+        would leave the instruction with an unresolved vreg name.
+        """
+        used: set[str] = set()
+        for vreg, preg in rename.items():
+            interval = self._vreg_interval.get(vreg)
+            if interval is None or interval.contains(current_pos):
+                used.add(preg)
+        for reg in self.phys_regs:
+            if reg not in used:
+                return reg
+        return self._evict_for_reload(rename, used, current_pos, protected_vregs)
+
+    def _evict_for_reload(
+        self, rename: dict[str, str], used: set[str], current_pos: int,
+        protected_vregs: set[str] | None = None,
+    ) -> str:
+        """Evict a live register to make room for a reload.
+
+        Picks the vreg whose interval ends farthest away, generates a
+        spill store to its stack slot, and records future reloads for
+        its remaining uses.
+
+        Vregs in *protected_vregs* are excluded from eviction — they are
+        needed by the instruction at *current_pos* and evicting them
+        would produce unresolved vreg names in the output.
+        """
+        protect = protected_vregs or set()
+        farthest_vreg: str | None = None
+        farthest_end = -1
+        for vreg, preg in rename.items():
+            if preg not in used:
+                continue
+            if vreg in protect:
+                continue
+            interval = self._vreg_interval.get(vreg)
+            if interval is not None and interval.end > farthest_end:
+                farthest_end = interval.end
+                farthest_vreg = vreg
+
+        if farthest_vreg is None:
+            return self.phys_regs[0]
+
+        evicted_reg = rename[farthest_vreg]
+        slot = self._get_spill_slot(farthest_vreg)
+        self._spilled.add(farthest_vreg)
+
+        # Emit spill store BEFORE the reload (evictions go before reloads)
+        self._evictions.setdefault(current_pos, []).append(
+            f"  sw {evicted_reg}, {slot}(sp)"
+            f"  # evict {farthest_vreg} for reload"
+        )
+
+        # Record future reloads for remaining uses of the evicted vreg
+        interval = self._vreg_interval.get(farthest_vreg)
+        if interval is not None:
+            for use_pos in interval.uses:
+                if use_pos > current_pos:
+                    self._reloads.setdefault(use_pos, []).append(
+                        (farthest_vreg, slot))
+
+        del rename[farthest_vreg]
+        return evicted_reg
 
     # ------------------------------------------------------------------
     # Report

--- a/scratchv/backend/register_alloc.py
+++ b/scratchv/backend/register_alloc.py
@@ -105,7 +105,6 @@ class RegisterAllocator:
 
         for instr in self.instructions:
             if instr.op == MachineOp.LABEL:
-                self._flush_regs()
                 self._emit(instr)
                 continue
 

--- a/scratchv/backend/riscv_encoder.py
+++ b/scratchv/backend/riscv_encoder.py
@@ -252,7 +252,20 @@ class RISCVAEncoder:
             word = _i_type(rd, rs1, imm, F3_ADD_SUB)
         elif op == "lw":
             rd = _reg_num(operands[0])
-            offset, rs1 = self._parse_mem(operands[1])
+            mem_op = operands[1]
+            if "(" in mem_op and ")" in mem_op:
+                before = mem_op[:mem_op.index("(")]
+                after = mem_op[mem_op.index("(") + 1:mem_op.index(")")]
+                if before in REG_MAP or before.startswith("x"):
+                    # Compiler syntax: lw rd, rs1(offset)
+                    rs1 = _reg_num(before)
+                    offset = self._parse_imm(after) if after else 0
+                else:
+                    # Standard syntax: lw rd, offset(rs1)
+                    offset = self._parse_imm(before) if before else 0
+                    rs1 = _reg_num(after)
+            else:
+                offset, rs1 = 0, 0
             word = _i_type(rd, rs1, offset, F3_LW, RVOpcode.LOAD)
         elif op == "sw":
             rs2 = _reg_num(operands[0])

--- a/scratchv/compiler.py
+++ b/scratchv/compiler.py
@@ -57,7 +57,7 @@ class CompilerConfig:
 
     backend: str = "riscv"
     optimize_level: str = "none"
-    reg_alloc: str = "greedy"
+    reg_alloc: str = "linear"
     dump_ir: bool = False
     verify: bool = False
     rtol: float = 1e-5
@@ -403,21 +403,17 @@ class CompilerDriver:
         selector = InstructionSelector(program)
         machine_instrs = selector.run()
 
-        alloc = RegisterAllocator(machine_instrs, mode=self.config.reg_alloc)
-        allocated = alloc.run()
-
-        # Optional: use linear-scan instead
+        # Linear-scan: skip greedy allocator, use liveness-driven allocator
         if self.config.reg_alloc == "linear":
             from scratchv.backend.regalloc_linear import (
                 LinearScanAllocator, block_from_machine_instrs,
             )
-            ls_insts = block_from_machine_instrs(allocated)
+            ls_insts = block_from_machine_instrs(machine_instrs)
             lsa = LinearScanAllocator()
-            intervals = lsa.compute_live_intervals(ls_insts)
-            lsa.allocate(intervals)
-            # Use linear-scan allocated code as assembly directly
-            return lsa.get_allocated_code(ls_insts)
+            return lsa.emit(ls_insts)
 
+        alloc = RegisterAllocator(machine_instrs, mode=self.config.reg_alloc)
+        allocated = alloc.run()
         emitter = AsmEmitter(allocated)
         return emitter.emit()
 

--- a/tests/stress/reg_pressure_32.dsl
+++ b/tests/stress/reg_pressure_32.dsl
@@ -1,0 +1,83 @@
+# Stress test: 32 simultaneously-live virtual registers
+# Fan-in tree over 32 distinct intermediate values using input variables
+# (no constants, to avoid the pre-existing add-with-immediate emitter bug).
+#
+# Peak liveness is at the first reduction instruction, where all 32
+# intermediate vregs are still alive: 32 > 19 (greedy) / 27 (linear scan).
+# This triggers the spill/reload path in both register allocators.
+
+# Layer 1: 32 values — each is x*2 (add of same register, valid RISC-V)
+v01 = add(x, x)
+v02 = add(x, x)
+v03 = add(x, x)
+v04 = add(x, x)
+v05 = add(x, x)
+v06 = add(x, x)
+v07 = add(x, x)
+v08 = add(x, x)
+v09 = add(x, x)
+v10 = add(x, x)
+v11 = add(x, x)
+v12 = add(x, x)
+v13 = add(x, x)
+v14 = add(x, x)
+v15 = add(x, x)
+v16 = add(x, x)
+v17 = add(x, x)
+v18 = add(x, x)
+v19 = add(x, x)
+v20 = add(x, x)
+v21 = add(x, x)
+v22 = add(x, x)
+v23 = add(x, x)
+v24 = add(x, x)
+v25 = add(x, x)
+v26 = add(x, x)
+v27 = add(x, x)
+v28 = add(x, x)
+v29 = add(x, x)
+v30 = add(x, x)
+v31 = add(x, x)
+v32 = add(x, x)
+
+# Layer 2: 16 reductions — PEAK LIVENESS: all 32 vregs still alive
+r01 = add(v01, v02)
+r02 = add(v03, v04)
+r03 = add(v05, v06)
+r04 = add(v07, v08)
+r05 = add(v09, v10)
+r06 = add(v11, v12)
+r07 = add(v13, v14)
+r08 = add(v15, v16)
+r09 = add(v17, v18)
+r10 = add(v19, v20)
+r11 = add(v21, v22)
+r12 = add(v23, v24)
+r13 = add(v25, v26)
+r14 = add(v27, v28)
+r15 = add(v29, v30)
+r16 = add(v31, v32)
+
+# Layer 3: 8 reductions
+s01 = add(r01, r02)
+s02 = add(r03, r04)
+s03 = add(r05, r06)
+s04 = add(r07, r08)
+s05 = add(r09, r10)
+s06 = add(r11, r12)
+s07 = add(r13, r14)
+s08 = add(r15, r16)
+
+# Layer 4: 4 reductions
+t01 = add(s01, s02)
+t02 = add(s03, s04)
+t03 = add(s05, s06)
+t04 = add(s07, s08)
+
+# Layer 5: 2 reductions
+u01 = add(t01, t02)
+u02 = add(t03, t04)
+
+# Layer 6: final reduction
+final = add(u01, u02)
+return final

--- a/tests/stress/reg_pressure_32.meta.json
+++ b/tests/stress/reg_pressure_32.meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "32-vreg stress test using input variables (no constants). Fan-in tree over 32 intermediate add(x,x) values triggers spill/reload path. 32 > 19 (greedy allocator register count).",
+  "expected_output_type": "return_value",
+  "inputs": {
+    "x": 1
+  },
+  "expected_return": 64
+}

--- a/tests/stress/reg_pressure_loop.dsl
+++ b/tests/stress/reg_pressure_loop.dsl
@@ -1,0 +1,15 @@
+# Loop + register pressure regression test.
+# Accumulator (acc) survives across loop back-edges while the loop body
+# creates a chain of dependent intermediates from x.
+# This tests that labels at the loop header don't corrupt register
+# mappings — the original _flush_regs() bug tore live ranges here.
+for i = 0, 10
+  v1 = add(x, x)
+  v2 = add(v1, x)
+  v3 = add(v2, v1)
+  v4 = add(v3, v2)
+  v5 = add(v4, v3)
+  v6 = add(v5, v4)
+  acc = add(acc, v6)
+endfor
+return acc

--- a/tests/stress/reg_pressure_loop.meta.json
+++ b/tests/stress/reg_pressure_loop.meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "Loop regression test: accumulator survives across 10 loop back-edges while loop body creates 6-chain of dependent intermediates (Fibonacci-like). Validates that LABEL at loop header does not corrupt vreg-to-physreg mappings across iterations.",
+  "expected_output_type": "return_value",
+  "inputs": {
+    "x": 1
+  },
+  "expected_return": 210
+}


### PR DESCRIPTION
修复了两个问题，
1. 寄存器分配时，ScratchV没有简单的活跃变量分析，导致寄存器spill到栈上时，不知道什么时候lw。
2. 无脑使用flush在切换到新bb时，会将所有寄存器spill到栈上，这也是为什么发现了问题一
 附修改review
[RA_commit_architect_review.md](https://github.com/user-attachments/files/29806562/RA_commit_architect_review.md)
ai建议的修改：
[pr-17.md](https://github.com/user-attachments/files/30384963/pr-17.md)

Implement liveness-driven spill→reload cycle in LinearScanAllocator:
- spill() now records reload positions for every future use of a spilled vreg; removes stale alloc_map entries after freeing a reg
- get_allocated_code() interleaves lw reloads before uses and sw spills after definitions
- New emit() one-shot entry point: intervals → allocate → codegen
- Fix compiler.py linear mode: process raw vreg instructions directly instead of re-scanning already-allocated physical registers
- Remove broken _flush_regs() at LABEL boundaries in greedy allocator that tore live ranges across labels and caused infinite loops