### PR TITLE
课题4 W5：DCE use-def 回溯

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,10 @@ pytest tests/ -v            # run all tests
 ## Adding a New Optimization Pass
 
 1. Create `scratchv/optimizer/my_pass.py`.
-2. Implement a class with a `run(program) → int` method (returns number of
-   transformations applied).
-3. Register it in `scratchv/main.py` → `run_optimizer()`.
+2. Subclass `OptimizationPass`, define a stable `name`, and implement
+   `optimize(program) → int` (returns the transformations from that call).
+3. Register it in `create_optimization_pass_manager()` in
+   `scratchv/compiler.py`.
 4. Add test cases (positive: should transform; negative: should not).
 5. Run `pytest` to verify.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,15 @@ pytest tests/ -v            # run all tests
 ## Adding a New Optimization Pass
 
 1. Create `scratchv/optimizer/my_pass.py`.
-2. Subclass `OptimizationPass`, define a stable `name`, and implement
-   `optimize(program) → int` (returns the transformations from that call).
-3. Register it in `create_optimization_pass_manager()` in
+2. Subclass `OptimizationPass` and define a stable, lowercase, kebab-case
+   `name` such as `"constant-folding"`. The manager uses this identifier in
+   ordered reports and failure diagnostics.
+3. Implement `optimize(program) → int`. It must return a non-negative count
+   of transformations made by that invocation, not a lifetime total.
+4. Register it in `create_optimization_pass_manager()` in
    `scratchv/compiler.py`.
-4. Add test cases (positive: should transform; negative: should not).
-5. Run `pytest` to verify.
+5. Add test cases (positive: should transform; negative: should not).
+6. Run `pytest` to verify.
 
 ## Documentation
 

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -77,26 +77,10 @@ def _parse_onnx(path: str) -> Program:
 
 def _optimize(program: Program, level: str) -> float:
     """Run optimizations. Returns elapsed time in seconds."""
-    if level == "none":
-        return 0.0
+    from scratchv.compiler import create_optimization_pass_manager
 
-    t0 = time.perf_counter()
-
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-
-    ConstantFolder(program).run()
-    DeadCodeEliminator(program).run()
-
-    if level == "all":
-        from scratchv.optimizer.peephole import IRPeepholeOptimizer
-        from scratchv.optimizer.muladd_fusion import MulAddFusion
-        from scratchv.optimizer.licm import LICM
-        IRPeepholeOptimizer(program).run()
-        MulAddFusion(program).run()
-        LICM(program).run()
-
-    return time.perf_counter() - t0
+    manager = create_optimization_pass_manager(level)
+    return manager.run(program).elapsed_seconds
 
 
 def _codegen_riscv(program: Program) -> tuple[str, float]:

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -76,7 +76,10 @@ def _parse_onnx(path: str) -> Program:
 
 
 def _optimize(program: Program, level: str) -> float:
-    """Run optimizations. Returns elapsed time in seconds."""
+    """Run the selected unified pipeline and return its reported elapsed time.
+
+    The ``none`` pipeline is empty, so its report is exactly ``0.0`` seconds.
+    """
     from scratchv.compiler import create_optimization_pass_manager
 
     manager = create_optimization_pass_manager(level)

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -146,11 +146,8 @@ def run_benchmark(model_name: str, model_path: str, *,
         result.ir_inst_count, result.ir_bb_count = _count_ir(program)
 
         # 2. Optimize
-        if optimize_level != "none":
-            result.optimize_time_s = _optimize(program, optimize_level)
-            result.ir_opt_inst_count, _ = _count_ir(program)
-        else:
-            result.ir_opt_inst_count = result.ir_inst_count
+        result.optimize_time_s = _optimize(program, optimize_level)
+        result.ir_opt_inst_count, _ = _count_ir(program)
 
         # 3. Codegen
         if backend == "llvm":

--- a/benchmarks/test_benchmark.py
+++ b/benchmarks/test_benchmark.py
@@ -76,7 +76,7 @@ def test_optimize(model_name: str, benchmark_models: dict[str, str]):
     create_optimization_pass_manager("all").run(program)
 
     inst_after = sum(1 for f in program.functions for bb in f.blocks for _ in bb.instructions)
-    assert inst_after >= 0, f"Optimization failed for {model_name}"
+    assert 0 < inst_after <= inst_before, f"Optimization failed for {model_name}"
     print(f"\n    {model_name}: {inst_before} → {inst_after} instructions")
 
 

--- a/benchmarks/test_benchmark.py
+++ b/benchmarks/test_benchmark.py
@@ -65,19 +65,15 @@ def test_parse_onnx(model_name: str, benchmark_models: dict[str, str]):
 @pytest.mark.parametrize("model_name", MODEL_PARAMS, ids=_model_id)
 def test_optimize(model_name: str, benchmark_models: dict[str, str]):
     """Parse + optimize, check IR is not empty."""
+    from scratchv.compiler import create_optimization_pass_manager
     from scratchv.frontend.onnx_parser import ONNXParser
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-    from scratchv.optimizer.peephole import IRPeepholeOptimizer
 
     path = benchmark_models[model_name]
     program = ONNXParser().parse(path)
 
     inst_before = sum(1 for f in program.functions for bb in f.blocks for _ in bb.instructions)
 
-    ConstantFolder(program).run()
-    DeadCodeEliminator(program).run()
-    IRPeepholeOptimizer(program).run()
+    create_optimization_pass_manager("all").run(program)
 
     inst_after = sum(1 for f in program.functions for bb in f.blocks for _ in bb.instructions)
     assert inst_after >= 0, f"Optimization failed for {model_name}"
@@ -92,9 +88,8 @@ def test_optimize(model_name: str, benchmark_models: dict[str, str]):
 @pytest.mark.parametrize("backend", BACKEND_PARAMS)
 def test_codegen_riscv(model_name: str, backend: str, benchmark_models: dict[str, str]):
     """Parse + codegen → RISC-V assembly, check output is non-empty."""
+    from scratchv.compiler import create_optimization_pass_manager
     from scratchv.frontend.onnx_parser import ONNXParser
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
     from scratchv.backend.instruction_select import InstructionSelector
     from scratchv.backend.register_alloc import RegisterAllocator
     from scratchv.backend.asm_emit import AsmEmitter
@@ -102,8 +97,7 @@ def test_codegen_riscv(model_name: str, backend: str, benchmark_models: dict[str
     path = benchmark_models[model_name]
     program = ONNXParser().parse(path)
 
-    ConstantFolder(program).run()
-    DeadCodeEliminator(program).run()
+    create_optimization_pass_manager("basic").run(program)
 
     selector = InstructionSelector(program)
     machine = selector.run()

--- a/docs/optimization_guide.md
+++ b/docs/optimization_guide.md
@@ -43,12 +43,19 @@ c = add(a, b)  →  c = 8 (replaced with load_const)
 
 **Already implemented** in `scratchv/optimizer/dead_code.py`.
 
-Removes instructions whose results are never referenced:
+W5 traces local definitions backwards from observable roots and removes the
+entire unreachable dependency chain:
 ```
-t1 = mul(a, b)     # no subsequent read of t1 → DELETE
-t2 = add(t1, c)     # t2 is read by ret → KEEP
-ret t2
+dead_lhs = const 2       # DELETE: only feeds dead_result
+dead_rhs = const 3       # DELETE: only feeds dead_result
+dead_result = mul(dead_lhs, dead_rhs)  # DELETE
+live = add(a, b)         # KEEP: reached from RETURN
+ret live                 # KEEP: observable root
 ```
+
+The W5 analysis is intentionally limited to functions with exactly one basic
+block. Multi-block functions, duplicate SSA names, and non-empty `phi_nodes`
+remain unchanged until W6 adds safe cross-block analysis.
 
 ---
 

--- a/docs/optimization_guide.md
+++ b/docs/optimization_guide.md
@@ -3,8 +3,10 @@
 Six beginner-friendly optimization passes for ScratchV, ordered by difficulty.
 Each pass can be implemented as a standalone task.
 
-All IR passes implement `OptimizationPass.optimize(program) -> int`. Use the
-canonical factory when selecting an optimization level:
+All IR passes define a stable `name` and implement
+`OptimizationPass.optimize(self, program: Program) -> int`. The return value is
+the non-negative number of transformations made by the current invocation.
+Use the canonical factory when selecting an optimization level:
 
 ```python
 from scratchv.compiler import create_optimization_pass_manager
@@ -13,6 +15,10 @@ manager = create_optimization_pass_manager("all")
 report = manager.run(program)
 print(report.total_changes)
 ```
+
+`manager.run()` returns an immutable `OptimizationReport`. Its ordered
+`executions` contain each pass name, change count, and elapsed time;
+`total_changes` and `elapsed_seconds` summarize the complete pipeline.
 
 The main CLI accepts `--opt-level none|basic|all`; `--optimize` remains a
 compatibility alias. The standalone LLVM tool has a separate numeric
@@ -82,20 +88,26 @@ Scans assembly for redundant patterns and removes them:
 ```python
 class PeepholeOptimizer:
     def optimize(self, program: Program) -> int:
+        changes = 0
         for func in program.functions:
             for block in func.blocks:
-                self._optimize_block(block)
+                changes += self._optimize_block(block)
+        return changes
 
-    def _optimize_block(self, block):
+    def _optimize_block(self, block) -> int:
+        changes = 0
         i = 0
         while i < len(block.instructions):
             if self._is_addi_zero(block.instructions[i]):
                 block.instructions.pop(i)
+                changes += 1
                 continue
             elif self._is_jump_to_next(block, i):
                 block.instructions.pop(i)
+                changes += 1
                 continue
             i += 1
+        return changes
 ```
 
 ---
@@ -125,13 +137,18 @@ for out_y in range(H_out):
 ```python
 class LICM:
     def optimize(self, program: Program) -> int:
+        changes = 0
         for func in program.functions:
-            self._find_loops_and_hoist(func)
+            changes += self._find_loops_and_hoist(func)
+        return changes
 
-    def _find_loops_and_hoist(self, func):
+    def _find_loops_and_hoist(self, func) -> int:
+        hoisted_count = 0
         # 1. Find FOR/ENDFOR pairs
         # 2. Identify instructions whose operands don't change in loop
         # 3. Move them before the FOR instruction
+        # 4. Increment hoisted_count for each moved instruction
+        return hoisted_count
 ```
 
 ---

--- a/docs/optimization_guide.md
+++ b/docs/optimization_guide.md
@@ -20,8 +20,9 @@ print(report.total_changes)
 `executions` contain each pass name, change count, and elapsed time;
 `total_changes` and `elapsed_seconds` summarize the complete pipeline.
 
-The main CLI accepts `--opt-level none|basic|all`; `--optimize` remains a
-compatibility alias. The standalone LLVM tool has a separate numeric
+The main CLI accepts `--opt-level none|basic|all`; `--optimize` remains an
+alias for the option name and still requires one of those three values. A bare
+`--optimize` is invalid. The standalone LLVM tool has a separate numeric
 `--opt-level 0|1|2|3` option.
 
 ---

--- a/docs/optimization_guide.md
+++ b/docs/optimization_guide.md
@@ -3,6 +3,21 @@
 Six beginner-friendly optimization passes for ScratchV, ordered by difficulty.
 Each pass can be implemented as a standalone task.
 
+All IR passes implement `OptimizationPass.optimize(program) -> int`. Use the
+canonical factory when selecting an optimization level:
+
+```python
+from scratchv.compiler import create_optimization_pass_manager
+
+manager = create_optimization_pass_manager("all")
+report = manager.run(program)
+print(report.total_changes)
+```
+
+The main CLI accepts `--opt-level none|basic|all`; `--optimize` remains a
+compatibility alias. The standalone LLVM tool has a separate numeric
+`--opt-level 0|1|2|3` option.
+
 ---
 
 ## 1. Constant Folding (⭐)
@@ -66,7 +81,7 @@ Scans assembly for redundant patterns and removes them:
 **Implementation** in `scratchv/optimizer/peephole.py`:
 ```python
 class PeepholeOptimizer:
-    def run(self, program: Program) -> int:
+    def optimize(self, program: Program) -> int:
         for func in program.functions:
             for block in func.blocks:
                 self._optimize_block(block)
@@ -109,7 +124,7 @@ for out_y in range(H_out):
 **Implementation** in `scratchv/optimizer/licm.py`:
 ```python
 class LICM:
-    def run(self, program: Program) -> int:
+    def optimize(self, program: Program) -> int:
         for func in program.functions:
             self._find_loops_and_hoist(func)
 

--- a/docs/topics/04-IR优化器框架.md
+++ b/docs/topics/04-IR优化器框架.md
@@ -125,22 +125,37 @@ scratchv model.onnx --optimize basic
 ```python
 class DeadCodeEliminator:
     def optimize(self, program):
-        used = set()
-        # 从每条"有副作用的"指令开始回溯
-        for instr in self._effectful_instructions(program):
-            self._mark_used(instr, used)
-        # 删除不在 used 集合中的指令
-        for block in all_blocks:
-            block.instructions = [i for i in block.instructions if i in used]
-        return removed_count
+        removed = 0
+        for function in program.functions:
+            # W5 只处理单块函数；跨块 use-def 留给 W6。
+            if len(function.blocks) != 1:
+                continue
+            block = function.blocks[0]
+            definitions = self._build_definitions(block.instructions)
+            if block.phi_nodes or definitions is None:
+                continue
+            live_ids = set()
+            for instr in block.instructions:
+                if self._is_effect_root(instr):
+                    self._mark_used(instr, definitions, live_ids)
+            survivors = [i for i in block.instructions if id(i) in live_ids]
+            removed += len(block.instructions) - len(survivors)
+            block.instructions = survivors
+        return removed
 
-    def _mark_used(self, instr, used):
-        if instr in used:
+    def _mark_used(self, instr, definitions, live_ids):
+        if id(instr) in live_ids:
             return
-        used.add(instr)
-        for op in instr.operands:
-            self._mark_used(op.defining_instruction, used)  # 递归
+        live_ids.add(id(instr))
+        for operand in instr.operands:
+            producer = definitions.get(operand.name)
+            if producer is not None:
+                self._mark_used(producer, definitions, live_ids)
 ```
+
+W5 的活性根包括 `STORE`、`RETURN`、`BR`、`BR_IF`、`FOR`、`ENDFOR`、
+`ALLOCA` 以及所有没有目标值的指令。重复 SSA 名称或非空 `phi_nodes` 会使
+该函数保守保持不变。
 
 ### LICM 的循环不变量检测
 

--- a/docs/topics/04-IR优化器框架.md
+++ b/docs/topics/04-IR优化器框架.md
@@ -113,7 +113,8 @@ for execution in report.executions:
     print(execution.name, execution.changes, execution.elapsed_seconds)
 ```
 
-主命令行使用 `--opt-level none|basic|all`；旧参数名 `--optimize` 暂作兼容别名。
+主命令行使用 `--opt-level none|basic|all`；旧参数名 `--optimize` 暂作参数名的
+兼容别名，仍须显式提供三个级别之一，裸 `--optimize` 不合法。
 
 ```bash
 scratchv model.onnx --opt-level basic

--- a/docs/topics/04-IR优化器框架.md
+++ b/docs/topics/04-IR优化器框架.md
@@ -84,11 +84,22 @@ IR 优化器框架包含 5 个 IR 层面的优化 pass，它们共享相同接�
 所有 pass 实现相同签名：
 ```python
 class OptimizationPass:
-    name: str
+    @property
+    def name(self) -> str:
+        """返回稳定的小写连字符名称，如 constant-folding。"""
+        ...
 
     def optimize(self, program: Program) -> int:
-        """对 Program 原地优化，返回变更次数"""
+        """对 Program 原地优化，返回本次调用的非负变更次数。"""
         ...
+```
+
+`name` 是报告和失败诊断中使用的稳定标识符；PassManager 按注册顺序
+执行，不会根据名称排序或去重。具体 pass 可以用类属性实现：
+
+```python
+class ConstantFolder(OptimizationPass):
+    name = "constant-folding"
 ```
 
 默认管线由唯一工厂创建，避免主编译器与 benchmark 各自维护 Pass 列表：
@@ -103,6 +114,11 @@ for execution in report.executions:
 ```
 
 主命令行使用 `--opt-level none|basic|all`；旧参数名 `--optimize` 暂作兼容别名。
+
+```bash
+scratchv model.onnx --opt-level basic
+scratchv model.onnx --optimize basic
+```
 
 ### 死代码消除的回溯标记
 

--- a/docs/topics/04-IR优化器框架.md
+++ b/docs/topics/04-IR优化器框架.md
@@ -84,10 +84,25 @@ IR 优化器框架包含 5 个 IR 层面的优化 pass，它们共享相同接�
 所有 pass 实现相同签名：
 ```python
 class OptimizationPass:
+    name: str
+
     def optimize(self, program: Program) -> int:
         """对 Program 原地优化，返回变更次数"""
         ...
 ```
+
+默认管线由唯一工厂创建，避免主编译器与 benchmark 各自维护 Pass 列表：
+
+```python
+from scratchv.compiler import create_optimization_pass_manager
+
+manager = create_optimization_pass_manager("basic")
+report = manager.run(program)
+for execution in report.executions:
+    print(execution.name, execution.changes, execution.elapsed_seconds)
+```
+
+主命令行使用 `--opt-level none|basic|all`；旧参数名 `--optimize` 暂作兼容别名。
 
 ### 死代码消除的回溯标记
 

--- a/docs/topics/archive/optimizer_framework.md
+++ b/docs/topics/archive/optimizer_framework.md
@@ -1,5 +1,8 @@
 # Topic: IR 优化器框架 (Optimizer Framework)
 
+> **归档说明：** 本文保留为课题历史摘要；当前公共接口以
+> [`docs/topics/04-IR优化器框架.md`](../04-IR优化器框架.md) 和实际代码为准。
+
 > **源文件**: `scratchv/optimizer/`
 > **层级**: IR → IR (源和目标都是 IR Program)
 > **策略**: 所有 pass 原地修改 Program, 返回变更计数
@@ -98,7 +101,7 @@ if changes > 0:
     print(f"Folded {changes} constants")
 ```
 
-所有 pass 遵循相同接口。默认三级管线通过唯一工厂创建：
+所有 pass 遵循相同接口。当前实现的默认三级管线通过唯一工厂函数创建：
 
 ```python
 from scratchv.compiler import create_optimization_pass_manager
@@ -108,12 +111,19 @@ report = manager.run(program)
 print(report.total_changes)
 ```
 
-编译器入口和 benchmark 共用该工厂：`none` 创建空管线，`basic` 创建常量折叠与
-死代码消除，`all` 按上表注册全部五个 pass。`manager.run()` 返回不可变的
+编译器入口和 benchmark 共用该工厂，当前映射为：
+
+- `none`：空管线
+- `basic`：`constant-folding` → `dead-code-elim`
+- `all`：`constant-folding` → `dead-code-elim` → `ir-peephole` →
+  `muladd-fusion` → `licm`
+
+`manager.run()` 返回不可变的
 `OptimizationReport`；其 `executions` 按执行顺序记录 pass 名称、变更数和耗时，
 `total_changes` 与 `elapsed_seconds` 提供总计。
 
-主 CLI 使用 `--opt-level none|basic|all`，并保留 `--optimize` 兼容别名。
+主 CLI 使用 `--opt-level none|basic|all`。`--optimize` 只是参数名的兼容别名，
+仍须显式提供 `none`、`basic` 或 `all`；裸 `--optimize` 不合法。
 
 ```bash
 scratchv model.onnx --opt-level all

--- a/docs/topics/archive/optimizer_framework.md
+++ b/docs/topics/archive/optimizer_framework.md
@@ -98,7 +98,17 @@ if changes > 0:
     print(f"Folded {changes} constants")
 ```
 
-所有 pass 遵循相同接口，可在 `PassManager` 中链式调用。
+所有 pass 遵循相同接口。默认三级管线通过唯一工厂创建：
+
+```python
+from scratchv.compiler import create_optimization_pass_manager
+
+manager = create_optimization_pass_manager("all")
+report = manager.run(program)
+print(report.total_changes)
+```
+
+主 CLI 使用 `--opt-level none|basic|all`，并保留 `--optimize` 兼容别名。
 
 ## 相关 Topic
 

--- a/docs/topics/archive/optimizer_framework.md
+++ b/docs/topics/archive/optimizer_framework.md
@@ -108,7 +108,17 @@ report = manager.run(program)
 print(report.total_changes)
 ```
 
+编译器入口和 benchmark 共用该工厂：`none` 创建空管线，`basic` 创建常量折叠与
+死代码消除，`all` 按上表注册全部五个 pass。`manager.run()` 返回不可变的
+`OptimizationReport`；其 `executions` 按执行顺序记录 pass 名称、变更数和耗时，
+`total_changes` 与 `elapsed_seconds` 提供总计。
+
 主 CLI 使用 `--opt-level none|basic|all`，并保留 `--optimize` 兼容别名。
+
+```bash
+scratchv model.onnx --opt-level all
+scratchv model.onnx --optimize all
+```
 
 ## 相关 Topic
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -218,8 +218,9 @@ lli model.ll                       # LLVM JIT execution
 #    (before vs after optimization)
 ```
 
-`--optimize all` 仍是主 CLI 的兼容别名；新文档优先使用规范写法
-`--opt-level all`。
+> **Note:** 核心 CLI 中 `--optimize` 只是 `--opt-level` 的参数名兼容别名，
+> 仍须显式提供 `none`、`basic` 或 `all`。例如 `--optimize all` 等价于
+> `--opt-level all`；裸 `--optimize` 不合法。新文档优先使用后者。
 
 ---
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -218,6 +218,9 @@ lli model.ll                       # LLVM JIT execution
 #    (before vs after optimization)
 ```
 
+`--optimize all` 仍是主 CLI 的兼容别名；新文档优先使用规范写法
+`--opt-level all`。
+
 ---
 
 ## LLVM IR Verification

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -201,10 +201,10 @@ Add verification to your workflow:
 
 ```bash
 # 1. Compile with ScratchV (RISC-V backend)
-scratchv model.onnx -o output.s --optimize
+scratchv model.onnx -o output.s --opt-level all
 
 # 2. Compile with LLVM backend
-scratchv model.onnx --backend llvm -o model.ll --optimize
+scratchv model.onnx --backend llvm -o model.ll --opt-level all
 
 # 3. Verify against ONNX Runtime
 scratchv model.onnx --verify

--- a/examples/end_to_end_pipeline.py
+++ b/examples/end_to_end_pipeline.py
@@ -108,12 +108,9 @@ def demo_matmul(backend: str):
     program = parser.parse(dsl_source)
 
     # Optimize
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder()
-    folded = folder.optimize(program)
-    elim = DeadCodeEliminator()
-    eliminated = elim.optimize(program)
+    from scratchv.compiler import create_optimization_pass_manager
+    report = create_optimization_pass_manager("basic").run(program)
+    folded, eliminated = (item.changes for item in report.executions)
     print(f"  Optimizer: {folded} folded, {eliminated} eliminated")
 
     from scratchv.backend.llvm_codegen import LLVMCodegen
@@ -163,15 +160,8 @@ return z
     # With optimization
     parser2 = DSLParser()
     program2 = parser2.parse(dsl_source)
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-    from scratchv.optimizer.peephole import IRPeepholeOptimizer
-    folder = ConstantFolder()
-    folder.optimize(program2)
-    elim = DeadCodeEliminator()
-    elim.optimize(program2)
-    peep = IRPeepholeOptimizer()
-    peep.optimize(program2)
+    from scratchv.compiler import create_optimization_pass_manager
+    create_optimization_pass_manager("all").run(program2)
     codegen2 = LLVMCodegen(program2)
     print("After optimization (fold + dce + peephole):")
     print(codegen2.emit()[:400])

--- a/examples/end_to_end_pipeline.py
+++ b/examples/end_to_end_pipeline.py
@@ -110,10 +110,10 @@ def demo_matmul(backend: str):
     # Optimize
     from scratchv.optimizer.constant_folding import ConstantFolder
     from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder(program)
-    folded = folder.run()
-    elim = DeadCodeEliminator(program)
-    eliminated = elim.run()
+    folder = ConstantFolder()
+    folded = folder.optimize(program)
+    elim = DeadCodeEliminator()
+    eliminated = elim.optimize(program)
     print(f"  Optimizer: {folded} folded, {eliminated} eliminated")
 
     from scratchv.backend.llvm_codegen import LLVMCodegen
@@ -166,12 +166,12 @@ return z
     from scratchv.optimizer.constant_folding import ConstantFolder
     from scratchv.optimizer.dead_code import DeadCodeEliminator
     from scratchv.optimizer.peephole import IRPeepholeOptimizer
-    folder = ConstantFolder(program2)
-    folder.run()
-    elim = DeadCodeEliminator(program2)
-    elim.run()
-    peep = IRPeepholeOptimizer(program2)
-    peep.run()
+    folder = ConstantFolder()
+    folder.optimize(program2)
+    elim = DeadCodeEliminator()
+    elim.optimize(program2)
+    peep = IRPeepholeOptimizer()
+    peep.optimize(program2)
     codegen2 = LLVMCodegen(program2)
     print("After optimization (fold + dce + peephole):")
     print(codegen2.emit()[:400])

--- a/examples/end_to_end_pipeline.py
+++ b/examples/end_to_end_pipeline.py
@@ -110,7 +110,11 @@ def demo_matmul(backend: str):
     # Optimize
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program)
-    folded, eliminated = (item.changes for item in report.executions)
+    changes_by_name = {
+        execution.name: execution.changes for execution in report.executions
+    }
+    folded = changes_by_name["constant-folding"]
+    eliminated = changes_by_name["dead-code-elim"]
     print(f"  Optimizer: {folded} folded, {eliminated} eliminated")
 
     from scratchv.backend.llvm_codegen import LLVMCodegen
@@ -161,7 +165,11 @@ return z
     parser2 = DSLParser()
     program2 = parser2.parse(dsl_source)
     from scratchv.compiler import create_optimization_pass_manager
-    create_optimization_pass_manager("all").run(program2)
+    report = create_optimization_pass_manager("all").run(program2)
+    print(
+        f"  Optimizer: {report.total_changes} change(s) "
+        f"across {len(report.executions)} passes"
+    )
     codegen2 = LLVMCodegen(program2)
     print("After optimization (fold + dce + peephole):")
     print(codegen2.emit()[:400])

--- a/examples/end_to_end_pipeline.py
+++ b/examples/end_to_end_pipeline.py
@@ -107,15 +107,20 @@ def demo_matmul(backend: str):
     parser = DSLParser()
     program = parser.parse(dsl_source)
 
-    # Optimize
+    # "basic" is the stable constant-folding -> dead-code-elim pipeline.
+    # run() optimizes program in place and returns an immutable report.
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program)
     changes_by_name = {
         execution.name: execution.changes for execution in report.executions
     }
-    folded = changes_by_name["constant-folding"]
-    eliminated = changes_by_name["dead-code-elim"]
-    print(f"  Optimizer: {folded} folded, {eliminated} eliminated")
+    folded_changes = changes_by_name["constant-folding"]
+    eliminated_changes = changes_by_name["dead-code-elim"]
+    print(
+        "  Optimizer: "
+        f"{folded_changes} constant fold(s), "
+        f"{eliminated_changes} dead-code elimination(s)"
+    )
 
     from scratchv.backend.llvm_codegen import LLVMCodegen
     codegen = LLVMCodegen(program)
@@ -161,7 +166,8 @@ return z
     print(codegen1.emit()[:400])
     print("...")
 
-    # With optimization
+    # "all" runs the five canonical passes in registration order.
+    # run() optimizes program2 in place and returns an immutable report.
     parser2 = DSLParser()
     program2 = parser2.parse(dsl_source)
     from scratchv.compiler import create_optimization_pass_manager
@@ -171,7 +177,7 @@ return z
         f"across {len(report.executions)} passes"
     )
     codegen2 = LLVMCodegen(program2)
-    print("After optimization (fold + dce + peephole):")
+    print("After full optimization:")
     print(codegen2.emit()[:400])
     print("...")
 

--- a/examples/llvm_optimization_pipeline.py
+++ b/examples/llvm_optimization_pipeline.py
@@ -46,14 +46,19 @@ return result
     parser2 = DSLParser()
     program2 = parser2.parse(dsl_source)
 
+    # "basic" is the stable constant-folding -> dead-code-elim pipeline.
+    # run() optimizes program2 in place and returns an immutable report.
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program2)
     changes_by_name = {
         execution.name: execution.changes for execution in report.executions
     }
-    folded = changes_by_name["constant-folding"]
-    eliminated = changes_by_name["dead-code-elim"]
-    print(f"  Folded: {folded}, Eliminated: {eliminated}")
+    folded_changes = changes_by_name["constant-folding"]
+    eliminated_changes = changes_by_name["dead-code-elim"]
+    print(
+        f"  Constant folds: {folded_changes}, "
+        f"dead-code eliminations: {eliminated_changes}"
+    )
 
     codegen2 = LLVMCodegen(program2)
     basic_ir = codegen2.emit()
@@ -61,12 +66,13 @@ return result
     print(f"  LLVM IR lines: {line_count_basic}")
 
     # --- With full optimization ---
-    print("\n[With full optimization: fold + dce + peephole]")
+    print("\n[With full optimization]")
     parser3 = DSLParser()
     program3 = parser3.parse(dsl_source)
 
+    # "all" runs the five canonical passes in registration order and mutates program3.
     report = create_optimization_pass_manager("all").run(program3)
-    print(f"  Full pipeline: {report.total_changes} optimizations")
+    print(f"  Full pipeline total changes: {report.total_changes}")
 
     codegen3 = LLVMCodegen(program3)
     opt_ir = codegen3.emit()

--- a/examples/llvm_optimization_pipeline.py
+++ b/examples/llvm_optimization_pipeline.py
@@ -46,12 +46,9 @@ return result
     parser2 = DSLParser()
     program2 = parser2.parse(dsl_source)
 
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder()
-    folded = folder.optimize(program2)
-    elim = DeadCodeEliminator()
-    eliminated = elim.optimize(program2)
+    from scratchv.compiler import create_optimization_pass_manager
+    report = create_optimization_pass_manager("basic").run(program2)
+    folded, eliminated = (item.changes for item in report.executions)
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     codegen2 = LLVMCodegen(program2)
@@ -64,13 +61,8 @@ return result
     parser3 = DSLParser()
     program3 = parser3.parse(dsl_source)
 
-    folder3 = ConstantFolder()
-    folder3.optimize(program3)
-    elim3 = DeadCodeEliminator()
-    elim3.optimize(program3)
-    from scratchv.optimizer.peephole import IRPeepholeOptimizer
-    peep = IRPeepholeOptimizer()
-    peeped = peep.optimize(program3)
+    report = create_optimization_pass_manager("all").run(program3)
+    peeped = report.executions[2].changes
     print(f"  Folded+DCE+Peephole: {peeped} optimizations")
 
     codegen3 = LLVMCodegen(program3)

--- a/examples/llvm_optimization_pipeline.py
+++ b/examples/llvm_optimization_pipeline.py
@@ -48,7 +48,11 @@ return result
 
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program2)
-    folded, eliminated = (item.changes for item in report.executions)
+    changes_by_name = {
+        execution.name: execution.changes for execution in report.executions
+    }
+    folded = changes_by_name["constant-folding"]
+    eliminated = changes_by_name["dead-code-elim"]
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     codegen2 = LLVMCodegen(program2)
@@ -62,8 +66,7 @@ return result
     program3 = parser3.parse(dsl_source)
 
     report = create_optimization_pass_manager("all").run(program3)
-    peeped = report.executions[2].changes
-    print(f"  Folded+DCE+Peephole: {peeped} optimizations")
+    print(f"  Full pipeline: {report.total_changes} optimizations")
 
     codegen3 = LLVMCodegen(program3)
     opt_ir = codegen3.emit()

--- a/examples/llvm_optimization_pipeline.py
+++ b/examples/llvm_optimization_pipeline.py
@@ -48,10 +48,10 @@ return result
 
     from scratchv.optimizer.constant_folding import ConstantFolder
     from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder(program2)
-    folded = folder.run()
-    elim = DeadCodeEliminator(program2)
-    eliminated = elim.run()
+    folder = ConstantFolder()
+    folded = folder.optimize(program2)
+    elim = DeadCodeEliminator()
+    eliminated = elim.optimize(program2)
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     codegen2 = LLVMCodegen(program2)
@@ -64,13 +64,13 @@ return result
     parser3 = DSLParser()
     program3 = parser3.parse(dsl_source)
 
-    folder3 = ConstantFolder(program3)
-    folder3.run()
-    elim3 = DeadCodeEliminator(program3)
-    elim3.run()
+    folder3 = ConstantFolder()
+    folder3.optimize(program3)
+    elim3 = DeadCodeEliminator()
+    elim3.optimize(program3)
     from scratchv.optimizer.peephole import IRPeepholeOptimizer
-    peep = IRPeepholeOptimizer(program3)
-    peeped = peep.run()
+    peep = IRPeepholeOptimizer()
+    peeped = peep.optimize(program3)
     print(f"  Folded+DCE+Peephole: {peeped} optimizations")
 
     codegen3 = LLVMCodegen(program3)

--- a/examples/onnx_llvm_verification.py
+++ b/examples/onnx_llvm_verification.py
@@ -56,12 +56,9 @@ def main():
 
     # Step 2: Optimize
     print("\n[2/5] Optimizing IR...")
-    from scratchv.optimizer.constant_folding import ConstantFolder
-    from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder()
-    folded = folder.optimize(program)
-    elim = DeadCodeEliminator()
-    eliminated = elim.optimize(program)
+    from scratchv.compiler import create_optimization_pass_manager
+    report = create_optimization_pass_manager("basic").run(program)
+    folded, eliminated = (item.changes for item in report.executions)
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     # Step 3: Generate LLVM IR

--- a/examples/onnx_llvm_verification.py
+++ b/examples/onnx_llvm_verification.py
@@ -56,14 +56,19 @@ def main():
 
     # Step 2: Optimize
     print("\n[2/5] Optimizing IR...")
+    # "basic" is the stable constant-folding -> dead-code-elim pipeline.
+    # run() optimizes program in place and returns an immutable report.
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program)
     changes_by_name = {
         execution.name: execution.changes for execution in report.executions
     }
-    folded = changes_by_name["constant-folding"]
-    eliminated = changes_by_name["dead-code-elim"]
-    print(f"  Folded: {folded}, Eliminated: {eliminated}")
+    folded_changes = changes_by_name["constant-folding"]
+    eliminated_changes = changes_by_name["dead-code-elim"]
+    print(
+        f"  Constant folds: {folded_changes}, "
+        f"dead-code eliminations: {eliminated_changes}"
+    )
 
     # Step 3: Generate LLVM IR
     print("\n[3/5] Generating LLVM IR...")

--- a/examples/onnx_llvm_verification.py
+++ b/examples/onnx_llvm_verification.py
@@ -58,10 +58,10 @@ def main():
     print("\n[2/5] Optimizing IR...")
     from scratchv.optimizer.constant_folding import ConstantFolder
     from scratchv.optimizer.dead_code import DeadCodeEliminator
-    folder = ConstantFolder(program)
-    folded = folder.run()
-    elim = DeadCodeEliminator(program)
-    eliminated = elim.run()
+    folder = ConstantFolder()
+    folded = folder.optimize(program)
+    elim = DeadCodeEliminator()
+    eliminated = elim.optimize(program)
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     # Step 3: Generate LLVM IR

--- a/examples/onnx_llvm_verification.py
+++ b/examples/onnx_llvm_verification.py
@@ -58,7 +58,11 @@ def main():
     print("\n[2/5] Optimizing IR...")
     from scratchv.compiler import create_optimization_pass_manager
     report = create_optimization_pass_manager("basic").run(program)
-    folded, eliminated = (item.changes for item in report.executions)
+    changes_by_name = {
+        execution.name: execution.changes for execution in report.executions
+    }
+    folded = changes_by_name["constant-folding"]
+    eliminated = changes_by_name["dead-code-elim"]
     print(f"  Folded: {folded}, Eliminated: {eliminated}")
 
     # Step 3: Generate LLVM IR

--- a/examples/verify_with_tinyfive.py
+++ b/examples/verify_with_tinyfive.py
@@ -14,8 +14,7 @@ from scratchv.frontend.dsl_parser import DSLParser
 from scratchv.backend.instruction_select import InstructionSelector
 from scratchv.backend.register_alloc import RegisterAllocator
 from scratchv.backend.asm_emit import AsmEmitter
-from scratchv.optimizer.constant_folding import ConstantFolder
-from scratchv.optimizer.dead_code import DeadCodeEliminator
+from scratchv.compiler import create_optimization_pass_manager
 
 
 def compile_and_count(path: str, optimize: bool = False) -> tuple[str, int]:
@@ -27,10 +26,8 @@ def compile_and_count(path: str, optimize: bool = False) -> tuple[str, int]:
     program = parser.parse(source)
 
     if optimize:
-        folder = ConstantFolder()
-        folded = folder.optimize(program)
-        elim = DeadCodeEliminator()
-        eliminated = elim.optimize(program)
+        report = create_optimization_pass_manager("basic").run(program)
+        folded, eliminated = (item.changes for item in report.executions)
         print(f"  Optimization: {folded} folded, {eliminated} eliminated")
 
     selector = InstructionSelector(program)

--- a/examples/verify_with_tinyfive.py
+++ b/examples/verify_with_tinyfive.py
@@ -27,7 +27,12 @@ def compile_and_count(path: str, optimize: bool = False) -> tuple[str, int]:
 
     if optimize:
         report = create_optimization_pass_manager("basic").run(program)
-        folded, eliminated = (item.changes for item in report.executions)
+        changes_by_name = {
+            execution.name: execution.changes
+            for execution in report.executions
+        }
+        folded = changes_by_name["constant-folding"]
+        eliminated = changes_by_name["dead-code-elim"]
         print(f"  Optimization: {folded} folded, {eliminated} eliminated")
 
     selector = InstructionSelector(program)

--- a/examples/verify_with_tinyfive.py
+++ b/examples/verify_with_tinyfive.py
@@ -26,14 +26,20 @@ def compile_and_count(path: str, optimize: bool = False) -> tuple[str, int]:
     program = parser.parse(source)
 
     if optimize:
+        # "basic" is the stable constant-folding -> dead-code-elim pipeline.
+        # run() optimizes program in place and returns an immutable report.
         report = create_optimization_pass_manager("basic").run(program)
         changes_by_name = {
             execution.name: execution.changes
             for execution in report.executions
         }
-        folded = changes_by_name["constant-folding"]
-        eliminated = changes_by_name["dead-code-elim"]
-        print(f"  Optimization: {folded} folded, {eliminated} eliminated")
+        folded_changes = changes_by_name["constant-folding"]
+        eliminated_changes = changes_by_name["dead-code-elim"]
+        print(
+            "  Optimization: "
+            f"{folded_changes} constant fold(s), "
+            f"{eliminated_changes} dead-code elimination(s)"
+        )
 
     selector = InstructionSelector(program)
     instrs = selector.run()

--- a/examples/verify_with_tinyfive.py
+++ b/examples/verify_with_tinyfive.py
@@ -27,10 +27,10 @@ def compile_and_count(path: str, optimize: bool = False) -> tuple[str, int]:
     program = parser.parse(source)
 
     if optimize:
-        folder = ConstantFolder(program)
-        folded = folder.run()
-        elim = DeadCodeEliminator(program)
-        eliminated = elim.run()
+        folder = ConstantFolder()
+        folded = folder.optimize(program)
+        elim = DeadCodeEliminator()
+        eliminated = elim.optimize(program)
         print(f"  Optimization: {folded} folded, {eliminated} eliminated")
 
     selector = InstructionSelector(program)

--- a/scratchv/compiler.py
+++ b/scratchv/compiler.py
@@ -1,6 +1,6 @@
 """Compiler driver and pass manager for ScratchV.
 
-Provides a ``PassManager`` that chains compiler passes together and a
+Provides a ``PassManager`` that runs IR optimization passes and a
 ``CompilerDriver`` that orchestrates the full compilation pipeline:
 parse → optimise → codegen → verify → emit.
 
@@ -21,9 +21,15 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
-from scratchv.pass_interface import CompilerPass, PassResult
+from scratchv.ir.types import Program
+from scratchv.pass_interface import (
+    OptimizationPass,
+    OptimizationPassError,
+    OptimizationReport,
+    PassExecutionStats,
+)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -80,81 +86,94 @@ class CompilerConfig:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class PassManager:
-    """Manages a sequence of compiler passes and runs them in order.
-
-    Each pass receives the output of the previous pass as its input. The
-    first pass receives the initial ``input_data`` provided to ``run()``.
+    """Register and run IR optimization passes in a deterministic order.
 
     Usage::
 
         pm = PassManager()
-        pm.add(ConstantFolder(program))
-        pm.add(DeadCodeEliminator(program))
-        result = pm.run(program)
+        pm.register(ConstantFolder())
+        pm.register(DeadCodeEliminator())
+        report = pm.run(program)
     """
 
     def __init__(self, name: str = "pipeline"):
+        if not isinstance(name, str):
+            raise TypeError("pipeline name must be a string")
+        if not name.strip():
+            raise ValueError("pipeline name must not be empty")
         self._name = name
-        self._passes: list[CompilerPass] = []
+        self._passes: list[OptimizationPass] = []
 
     @property
     def name(self) -> str:
         return self._name
 
     @property
-    def passes(self) -> list[CompilerPass]:
+    def passes(self) -> list[OptimizationPass]:
         return list(self._passes)
 
-    def add(self, pass_: CompilerPass) -> "PassManager":
-        """Add a pass to the end of the pipeline.  Returns self for chaining."""
+    def register(self, pass_: OptimizationPass) -> "PassManager":
+        """Append an optimization pass and return ``self`` for chaining."""
+        if not isinstance(pass_, OptimizationPass):
+            raise TypeError("registered pass must implement OptimizationPass")
+        if not isinstance(pass_.name, str):
+            raise TypeError("optimization pass name must be a string")
+        if not pass_.name.strip():
+            raise ValueError("optimization pass name must not be empty")
         self._passes.append(pass_)
         return self
 
-    def run(self, input_data: Any) -> PassResult:
-        """Run all passes sequentially.
+    def add(self, pass_: OptimizationPass) -> "PassManager":
+        """Compatibility alias for :meth:`register`."""
+        return self.register(pass_)
 
-        Returns the final ``PassResult``.  If any pass returns ``None``
-        data the pipeline stops early and returns the last result.
-        """
-        data = input_data
-        total_changes = 0
-        messages: list[str] = []
-        all_warnings: list[str] = []
-        timings: dict[str, float] = {}
+    def run(self, program: Program) -> OptimizationReport:
+        """Optimize ``program`` in place and return ordered execution stats."""
+        if not isinstance(program, Program):
+            raise TypeError("PassManager.run() requires a Program")
 
-        for p in self._passes:
+        executions: list[PassExecutionStats] = []
+        for index, pass_ in enumerate(self._passes):
             t0 = time.perf_counter()
             try:
-                result = p.run(data)
+                changes = pass_.optimize(program)
+                self._validate_change_count(changes)
             except Exception as exc:
-                return PassResult(
-                    data=None,
-                    changes=total_changes,
-                    message=f"Pass '{p.name}' failed: {exc}",
-                    warnings=all_warnings,
-                )
+                elapsed = time.perf_counter() - t0
+                completed_report = self._make_report(executions)
+                raise OptimizationPassError(
+                    pass_index=index,
+                    pass_name=pass_.name,
+                    elapsed_seconds=elapsed,
+                    completed_report=completed_report,
+                    cause=exc,
+                ) from exc
             elapsed = time.perf_counter() - t0
-            timings[p.name] = elapsed
-
-            if result.data is None:
-                return PassResult(
-                    data=None,
-                    changes=total_changes,
-                    message=f"Pipeline stopped after '{p.name}': {result.message}",
-                    warnings=all_warnings + result.warnings,
+            executions.append(
+                PassExecutionStats(
+                    index=index,
+                    name=pass_.name,
+                    changes=changes,
+                    elapsed_seconds=elapsed,
                 )
+            )
 
-            data = result.data
-            total_changes += result.changes
-            if result.message:
-                messages.append(f"[{p.name}] {result.message}")
-            all_warnings.extend(result.warnings)
+        return self._make_report(executions)
 
-        return PassResult(
-            data=data,
-            changes=total_changes,
-            message="; ".join(messages) if messages else "pipeline complete",
-            warnings=all_warnings,
+    @staticmethod
+    def _validate_change_count(changes: int) -> None:
+        if isinstance(changes, bool) or not isinstance(changes, int):
+            raise TypeError("optimization pass must return an integer change count")
+        if changes < 0:
+            raise ValueError("optimization pass change count must be non-negative")
+
+    def _make_report(self, executions: list[PassExecutionStats]) -> OptimizationReport:
+        records = tuple(executions)
+        return OptimizationReport(
+            pipeline_name=self._name,
+            executions=records,
+            total_changes=sum(item.changes for item in records),
+            elapsed_seconds=sum(item.elapsed_seconds for item in records),
         )
 
     def report(self) -> str:
@@ -163,6 +182,35 @@ class PassManager:
         for p in self._passes:
             lines.append(f"  {p.name}")
         return "\n".join(lines)
+
+
+def create_optimization_pass_manager(level: str) -> PassManager:
+    """Build the canonical ``none``/``basic``/``all`` IR pipeline."""
+    if not isinstance(level, str):
+        raise TypeError("optimization level must be a string")
+    if level not in {"none", "basic", "all"}:
+        raise ValueError("optimization level must be one of: none, basic, all")
+
+    manager = PassManager("optimizer")
+    if level == "none":
+        return manager
+
+    from scratchv.optimizer.constant_folding import ConstantFolder
+    from scratchv.optimizer.dead_code import DeadCodeEliminator
+
+    manager.register(ConstantFolder())
+    manager.register(DeadCodeEliminator())
+
+    if level == "all":
+        from scratchv.optimizer.licm import LICM
+        from scratchv.optimizer.muladd_fusion import MulAddFusion
+        from scratchv.optimizer.peephole import IRPeepholeOptimizer
+
+        manager.register(IRPeepholeOptimizer())
+        manager.register(MulAddFusion())
+        manager.register(LICM())
+
+    return manager
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -233,7 +281,6 @@ class CompilerDriver:
         Returns:
             A ``CompileResult`` with output text and statistics.
         """
-        errors: list[str] = []
         warnings: list[str] = []
 
         # Resolve output path
@@ -259,9 +306,24 @@ class CompilerDriver:
 
         # --- 3. Optimize ---
         opt_message = ""
-        if self.config.optimize_level != "none":
-            opt_result = self._run_optimizations(program)
-            opt_message = opt_result.message
+        try:
+            optimization_report = self._run_optimizations(program)
+        except (OptimizationPassError, TypeError, ValueError) as exc:
+            if isinstance(exc, OptimizationPassError):
+                completed_report = exc.completed_report
+            else:
+                completed_report = OptimizationReport("optimizer", (), 0, 0.0)
+            optimization_stats = self._optimization_stats(completed_report)
+            return CompileResult(
+                success=False,
+                errors=[f"Optimization error: {exc}"],
+                stats={
+                    "optimization": optimization_stats,
+                    "opt_message": opt_message,
+                    "cycle_report": "",
+                },
+            )
+        opt_message = self._optimization_message(optimization_report)
 
         ir_dump_after = ""
         if self.config.dump_ir:
@@ -316,7 +378,11 @@ class CompilerDriver:
             output_text=asm_text,
             output_path=output_path,
             ir_dump=ir_dump,
-            stats={"opt_message": opt_message, "cycle_report": cycle_report},
+            stats={
+                "optimization": self._optimization_stats(optimization_report),
+                "opt_message": opt_message,
+                "cycle_report": cycle_report,
+            },
             warnings=warnings,
         )
 
@@ -361,25 +427,35 @@ class CompilerDriver:
 
     # ── Internal: optimizations ─────────────────────────────────────────────
 
-    def _run_optimizations(self, program) -> PassResult:
+    def _run_optimizations(self, program: Program) -> OptimizationReport:
         """Run all configured optimization passes."""
-        from scratchv.optimizer.constant_folding import ConstantFolder
-        from scratchv.optimizer.dead_code import DeadCodeEliminator
+        manager = create_optimization_pass_manager(self.config.optimize_level)
+        return manager.run(program)
 
-        pm = PassManager("optimizer")
-        pm.add(_PassAdapter("constant-folding", ConstantFolder(program)))
-        pm.add(_PassAdapter("dead-code-elim", DeadCodeEliminator(program)))
+    def _optimization_stats(self, report: OptimizationReport) -> dict[str, Any]:
+        """Convert an immutable report to the CompileResult stats schema."""
+        return {
+            "level": self.config.optimize_level,
+            "total_changes": report.total_changes,
+            "elapsed_seconds": report.elapsed_seconds,
+            "passes": [
+                {
+                    "index": item.index,
+                    "name": item.name,
+                    "changes": item.changes,
+                    "elapsed_seconds": item.elapsed_seconds,
+                }
+                for item in report.executions
+            ],
+        }
 
-        if self.config.optimize_level == "all":
-            from scratchv.optimizer.peephole import IRPeepholeOptimizer
-            from scratchv.optimizer.muladd_fusion import MulAddFusion
-            from scratchv.optimizer.licm import LICM
-
-            pm.add(_PassAdapter("ir-peephole", IRPeepholeOptimizer(program)))
-            pm.add(_PassAdapter("muladd-fusion", MulAddFusion(program)))
-            pm.add(_PassAdapter("licm", LICM(program)))
-
-        return pm.run(program)
+    @staticmethod
+    def _optimization_message(report: OptimizationReport) -> str:
+        """Build the legacy human-readable optimization summary."""
+        return "; ".join(
+            f"[{item.name}] {item.changes} change(s)"
+            for item in report.executions
+        )
 
     # ── Internal: code generation ───────────────────────────────────────────
 
@@ -480,31 +556,3 @@ class CompilerDriver:
             warnings.append(f"Instruction count: {total}")
 
         return asm_text
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# _PassAdapter — wraps legacy passes that don't implement CompilerPass
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class _PassAdapter(CompilerPass):
-    """Adapter that wraps a legacy pass object into the ``CompilerPass`` API.
-
-    Legacy passes are expected to have a ``run()`` method that returns an
-    integer (number of changes) and mutate the data in place.
-    """
-
-    def __init__(self, name: str, legacy_pass: Any):
-        self._name = name
-        self._legacy = legacy_pass
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def run(self, input_data: Any) -> PassResult:
-        changes = self._legacy.run()
-        return PassResult(
-            data=input_data,
-            changes=changes,
-            message=f"{changes} change(s)",
-        )

--- a/scratchv/main.py
+++ b/scratchv/main.py
@@ -38,7 +38,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
     # ── Optimizations ───────────────────────────────────────────────────
     parser.add_argument(
-        "--optimize", choices=["none", "basic", "all"],
+        "--opt-level", "--optimize", dest="optimize_level",
+        choices=["none", "basic", "all"],
         default="none",
         help="Optimization level (none, basic, all)",
     )
@@ -136,7 +137,7 @@ def args_to_config(args: argparse.Namespace) -> CompilerConfig:
     """Translate parsed CLI arguments to a CompilerConfig."""
     return CompilerConfig(
         backend=args.backend,
-        optimize_level=args.optimize,
+        optimize_level=args.optimize_level,
         reg_alloc=args.reg_alloc,
         dump_ir=args.dump_ir,
         verify=args.verify,

--- a/scratchv/optimizer/constant_folding.py
+++ b/scratchv/optimizer/constant_folding.py
@@ -9,34 +9,33 @@ from __future__ import annotations
 from scratchv.ir.types import (
     OpCode, Instruction, BasicBlock, Function, Program,
 )
+from scratchv.pass_interface import OptimizationPass
 
 
-class ConstantFolder:
+class ConstantFolder(OptimizationPass):
     """Fold constant expressions in an IR Program."""
 
-    def __init__(self, program: Program):
-        self.program = program
-        self._stats = {"folded": 0}
+    name = "constant-folding"
 
-    def run(self) -> int:
+    def optimize(self, program: Program) -> int:
         """Run constant folding on all functions. Returns number of folds."""
-        for func in self.program.functions:
-            self._fold_function(func)
-        return self._stats["folded"]
+        return sum(self._fold_function(func) for func in program.functions)
 
-    def _fold_function(self, func: Function) -> None:
-        for block in func.blocks:
-            self._fold_block(block)
+    def _fold_function(self, func: Function) -> int:
+        return sum(self._fold_block(block) for block in func.blocks)
 
-    def _fold_block(self, block: BasicBlock) -> None:
+    def _fold_block(self, block: BasicBlock) -> int:
+        changes = 0
         new_instrs: list[Instruction] = []
         for instr in block.instructions:
             folded = self._try_fold(instr)
             if folded is not None:
                 new_instrs.append(folded)
+                changes += 1
             else:
                 new_instrs.append(instr)
         block.instructions = new_instrs
+        return changes
 
     def _try_fold(self, instr: Instruction) -> Instruction | None:
         """Try to fold an instruction. Returns a replacement or None."""
@@ -58,7 +57,6 @@ class ConstantFolder:
         if result is None:
             return None
 
-        self._stats["folded"] += 1
         dest = instr.dest
         if dest is not None:
             dest.is_constant = True

--- a/scratchv/optimizer/dead_code.py
+++ b/scratchv/optimizer/dead_code.py
@@ -1,14 +1,12 @@
-"""Dead code elimination pass.
+"""Dead-code elimination for ScratchV IR.
 
-Removes instructions whose result is never used.
-
+The pass traces value definitions backwards from observable instructions, then
+removes pure instructions that do not contribute to those roots.
 """
 
 from __future__ import annotations
 
-from scratchv.ir.types import (
-    OpCode, Instruction, BasicBlock, Function, Program,
-)
+from scratchv.ir.types import BasicBlock, Function, Instruction, OpCode, Program
 from scratchv.pass_interface import OptimizationPass
 
 
@@ -17,47 +15,8 @@ class DeadCodeEliminator(OptimizationPass):
 
     name = "dead-code-elim"
 
-    def optimize(self, program: Program) -> int:
-        """Run dead code elimination.
-
-        Returns number of eliminated instructions.
-        """
-        return sum(self._eliminate_function(func) for func in program.functions)
-
-    def _eliminate_function(self, func: Function) -> int:
-        return sum(self._eliminate_block(block) for block in func.blocks)
-
-    def _eliminate_block(self, block: BasicBlock) -> int:
-        changes = 0
-        # Collect all used value names
-        used: set[str | None] = set()
-        # Return values and branch targets are always live
-        for instr in block.instructions:
-            if instr.opcode in (
-                    OpCode.RETURN, OpCode.BR,
-                    OpCode.BR_IF, OpCode.STORE,
-                    OpCode.ENDFOR, OpCode.FOR):
-                used.add(instr.dest.name if instr.dest else None)
-            for op in instr.operands:
-                used.add(op.name)
-
-        # Filter: keep instructions with side effects or whose dest is used
-        new_instrs: list[Instruction] = []
-        for instr in block.instructions:
-            if self._is_side_effect(instr):
-                new_instrs.append(instr)
-            elif instr.dest is None or instr.dest.name in used:
-                new_instrs.append(instr)
-            else:
-                changes += 1
-
-        block.instructions = new_instrs
-        return changes
-
-    @staticmethod
-    def _is_side_effect(instr: Instruction) -> bool:
-        """Check if an instruction has side effects and must be kept."""
-        return instr.opcode in (
+    _EFFECT_ROOTS = frozenset(
+        {
             OpCode.STORE,
             OpCode.RETURN,
             OpCode.BR,
@@ -65,4 +24,66 @@ class DeadCodeEliminator(OptimizationPass):
             OpCode.FOR,
             OpCode.ENDFOR,
             OpCode.ALLOCA,
-        )
+        }
+    )
+
+    def optimize(self, program: Program) -> int:
+        """Eliminate dead instructions and return this invocation's count."""
+        return sum(self._eliminate_function(func) for func in program.functions)
+
+    def _eliminate_function(self, func: Function) -> int:
+        if len(func.blocks) != 1:
+            return 0
+        return self._eliminate_block(func.blocks[0])
+
+    def _eliminate_block(self, block: BasicBlock) -> int:
+        if block.phi_nodes:
+            return 0
+        definitions = self._build_definitions(block.instructions)
+        if definitions is None:
+            return 0
+        live_ids: set[int] = set()
+
+        for instr in block.instructions:
+            if self._is_effect_root(instr):
+                self._mark_used(instr, definitions, live_ids)
+
+        original_count = len(block.instructions)
+        block.instructions = [
+            instr for instr in block.instructions if id(instr) in live_ids
+        ]
+        return original_count - len(block.instructions)
+
+    @staticmethod
+    def _build_definitions(
+        instructions: list[Instruction],
+    ) -> dict[str, Instruction] | None:
+        definitions: dict[str, Instruction] = {}
+        for instr in instructions:
+            if instr.dest is None:
+                continue
+            if instr.dest.name in definitions:
+                return None
+            definitions[instr.dest.name] = instr
+        return definitions
+
+    def _mark_used(
+        self,
+        instr: Instruction,
+        definitions: dict[str, Instruction],
+        live_ids: set[int],
+    ) -> None:
+        instr_id = id(instr)
+        if instr_id in live_ids:
+            return
+        live_ids.add(instr_id)
+
+        for operand in instr.operands:
+            producer = definitions.get(operand.name)
+            if producer is not None:
+                self._mark_used(producer, definitions, live_ids)
+
+    @classmethod
+    def _is_effect_root(cls, instr: Instruction) -> bool:
+        """Return whether an instruction must remain observable."""
+        return instr.dest is None or instr.opcode in cls._EFFECT_ROOTS

--- a/scratchv/optimizer/dead_code.py
+++ b/scratchv/optimizer/dead_code.py
@@ -9,29 +9,26 @@ from __future__ import annotations
 from scratchv.ir.types import (
     OpCode, Instruction, BasicBlock, Function, Program,
 )
+from scratchv.pass_interface import OptimizationPass
 
 
-class DeadCodeEliminator:
+class DeadCodeEliminator(OptimizationPass):
     """Remove unused instructions from an IR Program."""
 
-    def __init__(self, program: Program):
-        self.program = program
-        self._stats = {"eliminated": 0}
+    name = "dead-code-elim"
 
-    def run(self) -> int:
+    def optimize(self, program: Program) -> int:
         """Run dead code elimination.
 
         Returns number of eliminated instructions.
         """
-        for func in self.program.functions:
-            self._eliminate_function(func)
-        return self._stats["eliminated"]
+        return sum(self._eliminate_function(func) for func in program.functions)
 
-    def _eliminate_function(self, func: Function) -> None:
-        for block in func.blocks:
-            self._eliminate_block(block)
+    def _eliminate_function(self, func: Function) -> int:
+        return sum(self._eliminate_block(block) for block in func.blocks)
 
-    def _eliminate_block(self, block: BasicBlock) -> None:
+    def _eliminate_block(self, block: BasicBlock) -> int:
+        changes = 0
         # Collect all used value names
         used: set[str | None] = set()
         # Return values and branch targets are always live
@@ -52,9 +49,10 @@ class DeadCodeEliminator:
             elif instr.dest is None or instr.dest.name in used:
                 new_instrs.append(instr)
             else:
-                self._stats["eliminated"] += 1
+                changes += 1
 
         block.instructions = new_instrs
+        return changes
 
     @staticmethod
     def _is_side_effect(instr: Instruction) -> bool:

--- a/scratchv/optimizer/licm.py
+++ b/scratchv/optimizer/licm.py
@@ -15,30 +15,27 @@ from __future__ import annotations
 from scratchv.ir.types import (
     OpCode, Instruction, BasicBlock, Function, Program,
 )
+from scratchv.pass_interface import OptimizationPass
 
 
-class LICM:
+class LICM(OptimizationPass):
     """Hoist loop-invariant code out of loops."""
 
-    def __init__(self, program: Program):
-        self.program = program
-        self._stats = {"hoisted": 0}
+    name = "licm"
 
-    def run(self) -> int:
+    def optimize(self, program: Program) -> int:
         """Run LICM on all functions.
 
         Returns number of hoisted instructions.
         """
-        for func in self.program.functions:
-            self._process_function(func)
-        return self._stats["hoisted"]
+        return sum(self._process_function(func) for func in program.functions)
 
-    def _process_function(self, func: Function) -> None:
-        for block in func.blocks:
-            self._process_block(block)
+    def _process_function(self, func: Function) -> int:
+        return sum(self._process_block(block) for block in func.blocks)
 
-    def _process_block(self, block: BasicBlock) -> None:
+    def _process_block(self, block: BasicBlock) -> int:
         """Find FOR/ENDFOR pairs in a block and hoist invariants."""
+        changes = 0
         instrs = block.instructions
         i = 0
         while i < len(instrs):
@@ -84,9 +81,11 @@ class LICM:
                 instrs.pop(idx)
                 instrs.insert(loop_start, instr)
                 loop_end += 1  # adjust for shift
-                self._stats["hoisted"] += 1
+                changes += 1
 
             i = loop_end + 1
+
+        return changes
 
     def _find_matching_endfor(self, instrs: list[Instruction], start: int):
         """Find matching ENDFOR for a FOR at given index."""

--- a/scratchv/optimizer/muladd_fusion.py
+++ b/scratchv/optimizer/muladd_fusion.py
@@ -14,23 +14,24 @@ The fused instruction is represented as MUL_ADD in IR:
 from __future__ import annotations
 
 from scratchv.ir.types import OpCode, Instruction, BasicBlock, Program
+from scratchv.pass_interface import OptimizationPass
 
 
-class MulAddFusion:
+class MulAddFusion(OptimizationPass):
     """Combine consecutive mul+add instruction pairs."""
 
-    def __init__(self, program: Program):
-        self.program = program
-        self._stats = {"fused": 0}
+    name = "muladd-fusion"
 
-    def run(self) -> int:
+    def optimize(self, program: Program) -> int:
         """Run mul-add fusion. Returns number of fusions performed."""
-        for func in self.program.functions:
-            for block in func.blocks:
-                self._fuse_block(block)
-        return self._stats["fused"]
+        return sum(
+            self._fuse_block(block)
+            for func in program.functions
+            for block in func.blocks
+        )
 
-    def _fuse_block(self, block: BasicBlock) -> None:
+    def _fuse_block(self, block: BasicBlock) -> int:
+        changes = 0
         instrs = block.instructions
         i = 0
         while i < len(instrs) - 1:
@@ -54,9 +55,11 @@ class MulAddFusion:
                 instrs[i] = fused
                 # Remove the original add
                 instrs.pop(i + 1)
-                self._stats["fused"] += 1
+                changes += 1
 
             i += 1
+
+        return changes
 
     def _matches_pattern(self, mul: Instruction, add: Instruction) -> bool:
         """Check if mul + add form a fusible pattern.

--- a/scratchv/optimizer/peephole.py
+++ b/scratchv/optimizer/peephole.py
@@ -10,26 +10,27 @@ Scans basic blocks for common redundant patterns:
 from __future__ import annotations
 
 from scratchv.ir.types import OpCode, Instruction, BasicBlock, Program
+from scratchv.pass_interface import OptimizationPass
 
 
-class IRPeepholeOptimizer:
+class IRPeepholeOptimizer(OptimizationPass):
     """Eliminate redundant instruction patterns in IR."""
 
-    def __init__(self, program: Program):
-        self.program = program
-        self._stats = {"eliminated": 0}
+    name = "ir-peephole"
 
-    def run(self) -> int:
+    def optimize(self, program: Program) -> int:
         """Run peephole optimization.
 
         Returns number of eliminated instructions.
         """
-        for func in self.program.functions:
-            for block in func.blocks:
-                self._optimize_block(block)
-        return self._stats["eliminated"]
+        return sum(
+            self._optimize_block(block)
+            for func in program.functions
+            for block in func.blocks
+        )
 
-    def _optimize_block(self, block: BasicBlock) -> None:
+    def _optimize_block(self, block: BasicBlock) -> int:
+        changes = 0
         instrs = block.instructions
         i = 0
         while i < len(instrs):
@@ -38,7 +39,7 @@ class IRPeepholeOptimizer:
             # Pattern 1: addi rd, rs, 0 → delete (no-op)
             if self._is_addi_zero(instr):
                 instrs.pop(i)
-                self._stats["eliminated"] += 1
+                changes += 1
                 continue
 
             # Pattern 2: mul rd, rs, 1 → mv rd, rs (use add rd, rs, x0)
@@ -50,7 +51,7 @@ class IRPeepholeOptimizer:
                     dest=dest,
                     operands=[src, self._make_zero_operand(instr)],
                 )
-                self._stats["eliminated"] += 1  # counts as optimization
+                changes += 1
                 i += 1
                 continue
 
@@ -62,17 +63,19 @@ class IRPeepholeOptimizer:
                     dest=dest,
                     attrs={"value": 0},
                 )
-                self._stats["eliminated"] += 1
+                changes += 1
                 i += 1
                 continue
 
             # Pattern 4: j L followed immediately by L:
             if self._is_jump_to_next(instrs, i):
                 instrs.pop(i)
-                self._stats["eliminated"] += 1
+                changes += 1
                 continue
 
             i += 1
+
+        return changes
 
     def _is_addi_zero(self, instr: Instruction) -> bool:
         """Check for: add rd, rs, 0  (or  add rd, rs, const where const=0)."""

--- a/scratchv/pass_interface.py
+++ b/scratchv/pass_interface.py
@@ -1,7 +1,8 @@
-"""Unified compiler pass interface for ScratchV.
+"""Unified compiler pass interfaces for ScratchV.
 
-All optimisation, analysis, and code-generation passes implement this
-protocol so they can be composed by ``PassManager`` and ``CompilerDriver``.
+IR optimization passes use the strongly typed ``OptimizationPass`` contract.
+The older generic ``CompilerPass`` and ``PassResult`` types remain available
+for compatibility with non-optimization callers.
 
 Usage::
 
@@ -25,6 +26,116 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
+
+from scratchv.ir.types import Program
+
+
+class OptimizationPass(ABC):
+    """Abstract interface implemented by every IR optimization pass."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return a stable, non-empty name for reports and diagnostics."""
+        ...
+
+    @abstractmethod
+    def optimize(self, program: Program) -> int:
+        """Optimize ``program`` in place and return this run's change count."""
+        ...
+
+
+@dataclass(frozen=True)
+class PassExecutionStats:
+    """Statistics for one execution in an optimization pipeline."""
+
+    index: int
+    name: str
+    changes: int
+    elapsed_seconds: float
+
+    def __post_init__(self) -> None:
+        if isinstance(self.index, bool) or not isinstance(self.index, int):
+            raise TypeError("pass execution index must be an integer")
+        if self.index < 0:
+            raise ValueError("pass execution index must be non-negative")
+        if not isinstance(self.name, str):
+            raise TypeError("pass execution name must be a string")
+        if not self.name.strip():
+            raise ValueError("pass execution name must not be empty")
+        if isinstance(self.changes, bool) or not isinstance(self.changes, int):
+            raise TypeError("pass changes must be an integer")
+        if self.changes < 0:
+            raise ValueError("pass changes must be non-negative")
+        if isinstance(self.elapsed_seconds, bool) or not isinstance(
+            self.elapsed_seconds, (int, float)
+        ):
+            raise TypeError("pass elapsed time must be numeric")
+        if self.elapsed_seconds < 0:
+            raise ValueError("pass elapsed time must be non-negative")
+
+
+@dataclass(frozen=True)
+class OptimizationReport:
+    """Ordered statistics produced by one optimization pipeline run."""
+
+    pipeline_name: str
+    executions: tuple[PassExecutionStats, ...]
+    total_changes: int
+    elapsed_seconds: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pipeline_name, str):
+            raise TypeError("pipeline name must be a string")
+        if not self.pipeline_name.strip():
+            raise ValueError("pipeline name must not be empty")
+        if not isinstance(self.executions, tuple):
+            raise TypeError("pipeline executions must be a tuple")
+        if [item.index for item in self.executions] != list(
+            range(len(self.executions))
+        ):
+            raise ValueError("pass execution indexes must be consecutive")
+        if isinstance(self.total_changes, bool) or not isinstance(
+            self.total_changes, int
+        ):
+            raise TypeError("total changes must be an integer")
+        if self.total_changes < 0:
+            raise ValueError("total changes must be non-negative")
+        if self.total_changes != sum(item.changes for item in self.executions):
+            raise ValueError("total changes must equal the execution sum")
+        if isinstance(self.elapsed_seconds, bool) or not isinstance(
+            self.elapsed_seconds, (int, float)
+        ):
+            raise TypeError("pipeline elapsed time must be numeric")
+        if self.elapsed_seconds < 0:
+            raise ValueError("pipeline elapsed time must be non-negative")
+
+
+class OptimizationPassError(RuntimeError):
+    """A pass failed or returned a value that violates its contract."""
+
+    def __init__(
+        self,
+        pass_index: int,
+        pass_name: str,
+        elapsed_seconds: float,
+        completed_report: OptimizationReport,
+        cause: Exception,
+    ):
+        self.pass_index = pass_index
+        self.pass_name = pass_name
+        self.elapsed_seconds = elapsed_seconds
+        self.completed_report = completed_report
+        self.cause = cause
+
+        # Descriptive aliases make the failure fields unambiguous to callers.
+        self.failed_index = pass_index
+        self.failed_name = pass_name
+        self.failed_elapsed_seconds = elapsed_seconds
+
+        super().__init__(
+            f"optimization pass #{pass_index} '{pass_name}' failed: {cause}"
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -64,8 +175,8 @@ class CompilerPass(ABC):
     Subclasses must implement ``name`` and ``run``.  ``stats`` is optional
     and defaults to an empty dict.
 
-    The ``run`` method accepts and returns arbitrary data — passes are
-    composed by ``PassManager`` which chains their inputs and outputs.
+    The legacy ``run`` method accepts and returns arbitrary data. IR
+    optimization pipelines instead use the typed ``OptimizationPass``.
     """
 
     @property

--- a/scratchv/pass_interface.py
+++ b/scratchv/pass_interface.py
@@ -121,17 +121,12 @@ class OptimizationPassError(RuntimeError):
         elapsed_seconds: float,
         completed_report: OptimizationReport,
         cause: Exception,
-    ):
+    ) -> None:
         self.pass_index = pass_index
         self.pass_name = pass_name
         self.elapsed_seconds = elapsed_seconds
         self.completed_report = completed_report
         self.cause = cause
-
-        # Descriptive aliases make the failure fields unambiguous to callers.
-        self.failed_index = pass_index
-        self.failed_name = pass_name
-        self.failed_elapsed_seconds = elapsed_seconds
 
         super().__init__(
             f"optimization pass #{pass_index} '{pass_name}' failed: {cause}"

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1,0 +1,300 @@
+"""Behavior tests for dead-code elimination."""
+
+from __future__ import annotations
+
+import pytest
+
+from scratchv.ir.builder import IRBuilder
+from scratchv.ir.types import BasicBlock, Function, Instruction, OpCode, Program, Value
+from scratchv.optimizer.dead_code import DeadCodeEliminator
+
+
+class TestDeadCodeUseDef:
+    def test_removes_complete_dead_dependency_chain(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+
+        lhs = builder.load_const(1.0)
+        rhs = builder.load_const(2.0)
+        builder.add(lhs, rhs)
+        live = builder.load_const(3.0)
+        builder.ret(live)
+        expected_survivors = tuple(block.instructions[-2:])
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 3
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, expected_survivors)
+        )
+        assert [instr.opcode for instr in block.instructions] == [
+            OpCode.LOAD_CONST,
+            OpCode.RETURN,
+        ]
+
+    def test_leaves_multi_block_function_unchanged(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        entry = builder.new_block("entry")
+        value = builder.load_const(1.0)
+        exit_block = builder.new_block("exit")
+        builder.ret(value)
+        entry_before = tuple(entry.instructions)
+        exit_before = tuple(exit_block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, entry.instructions)) == tuple(map(id, entry_before))
+        assert tuple(map(id, exit_block.instructions)) == tuple(
+            map(id, exit_before)
+        )
+
+    def test_leaves_duplicate_definitions_unchanged(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        first = Instruction(OpCode.LOAD_CONST, dest=Value("x"))
+        second = Instruction(OpCode.LOAD_CONST, dest=Value("x"))
+        ret = Instruction(OpCode.RETURN, operands=[second.dest])
+        block.add(first)
+        block.add(second)
+        block.add(ret)
+        instructions_before = tuple(block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+    def test_leaves_function_with_phi_nodes_unchanged(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        builder.load_const(1.0)
+        block.phi_nodes.append(Instruction(OpCode.ADD, dest=Value("phi")))
+        instructions_before = tuple(block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+    def test_preserves_complete_return_dependency_chain(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        lhs = builder.load_const(2.0)
+        rhs = builder.load_const(3.0)
+        added = builder.add(lhs, rhs)
+        factor = builder.load_const(4.0)
+        result = builder.mul(added, factor)
+        builder.ret(result)
+        instructions_before = tuple(block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+    def test_removes_interleaved_dead_chains_without_reordering_live_code(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        live_lhs = builder.load_const(2.0)
+        first_dead_source = builder.load_const(10.0)
+        live_rhs = builder.load_const(3.0)
+        builder.neg(first_dead_source)
+        second_dead_source = builder.load_const(20.0)
+        live_result = builder.add(live_lhs, live_rhs)
+        builder.exp(second_dead_source)
+        builder.ret(live_result)
+        expected_survivors = tuple(
+            block.instructions[index] for index in (0, 2, 5, 7)
+        )
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 4
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, expected_survivors)
+        )
+
+    def test_preserves_store_pointer_and_value_dependencies(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        pointer = builder.alloca(1)
+        lhs = builder.load_const(2.0)
+        rhs = builder.load_const(3.0)
+        stored = builder.add(lhs, rhs)
+        builder.store(pointer, stored)
+        builder.load_const(99.0)
+        expected_survivors = tuple(block.instructions[:-1])
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 1
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, expected_survivors)
+        )
+
+    def test_preserves_branch_condition_dependency_chain(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        lhs = builder.load_const(2.0)
+        rhs = builder.load_const(3.0)
+        condition = builder.sub(lhs, rhs)
+        builder.br_if(condition, "then", "else")
+        instructions_before = tuple(block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+    @pytest.mark.parametrize(
+        "opcode",
+        [
+            OpCode.STORE,
+            OpCode.RETURN,
+            OpCode.BR,
+            OpCode.BR_IF,
+            OpCode.FOR,
+            OpCode.ENDFOR,
+            OpCode.ALLOCA,
+        ],
+    )
+    def test_preserves_each_effect_root(self, opcode):
+        program = Program()
+        function = Function("test")
+        block = BasicBlock("entry")
+        root = Instruction(opcode, dest=Value("result"))
+        block.add(root)
+        function.add_block(block)
+        program.add_function(function)
+
+        changes = DeadCodeEliminator().optimize(program)
+
+        assert changes == 0
+        assert len(block.instructions) == 1
+        assert block.instructions[0] is root
+
+    @pytest.mark.parametrize("opcode", [OpCode.LABEL, OpCode.ADD])
+    def test_preserves_destless_instruction_conservatively(self, opcode):
+        program = Program()
+        function = Function("test")
+        block = BasicBlock("entry")
+        destless_pure_instruction = Instruction(opcode)
+        block.add(destless_pure_instruction)
+        function.add_block(block)
+        program.add_function(function)
+
+        changes = DeadCodeEliminator().optimize(program)
+
+        assert changes == 0
+        assert len(block.instructions) == 1
+        assert block.instructions[0] is destless_pure_instruction
+
+    def test_treats_implicit_inputs_as_live_leaves(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        result = builder.add(Value("left_input"), Value("right_input"))
+        builder.ret(result)
+        instructions_before = tuple(block.instructions)
+
+        changes = DeadCodeEliminator().optimize(builder.program)
+
+        assert changes == 0
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+    def test_repeated_invocations_report_only_current_changes(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        builder.new_block("entry")
+        lhs = builder.load_const(1.0)
+        rhs = builder.load_const(2.0)
+        builder.add(lhs, rhs)
+        live = builder.load_const(3.0)
+        builder.ret(live)
+        eliminator = DeadCodeEliminator()
+
+        first_changes = eliminator.optimize(builder.program)
+        second_changes = eliminator.optimize(builder.program)
+
+        assert (first_changes, second_changes) == (3, 0)
+
+    def test_handles_empty_program(self):
+        empty_program = Program()
+        zero_block_program = Program()
+        zero_block_program.add_function(Function("empty"))
+
+        assert (
+            DeadCodeEliminator().optimize(empty_program),
+            DeadCodeEliminator().optimize(zero_block_program),
+        ) == (0, 0)
+
+    def test_analyzes_same_value_name_independently_per_function(self):
+        program = Program()
+        live_function = Function("live")
+        live_block = live_function.new_block("entry")
+        live_value = Value("x")
+        live_definition = Instruction(OpCode.LOAD_CONST, dest=live_value)
+        live_return = Instruction(OpCode.RETURN, operands=[live_value])
+        live_block.add(live_definition)
+        live_block.add(live_return)
+        program.add_function(live_function)
+
+        dead_function = Function("dead")
+        dead_block = dead_function.new_block("entry")
+        dead_definition = Instruction(OpCode.LOAD_CONST, dest=Value("x"))
+        dead_return = Instruction(OpCode.RETURN)
+        dead_block.add(dead_definition)
+        dead_block.add(dead_return)
+        program.add_function(dead_function)
+
+        changes = DeadCodeEliminator().optimize(program)
+
+        assert changes == 1
+        assert live_block.instructions == [live_definition, live_return]
+        assert dead_block.instructions == [dead_return]
+
+    def test_terminates_on_cyclic_malformed_dependencies(self):
+        program = Program()
+        function = Function("test")
+        block = function.new_block("entry")
+        first_value = Value("first")
+        second_value = Value("second")
+        first = Instruction(
+            OpCode.ADD,
+            dest=first_value,
+            operands=[second_value],
+        )
+        second = Instruction(
+            OpCode.ADD,
+            dest=second_value,
+            operands=[first_value],
+        )
+        ret = Instruction(OpCode.RETURN, operands=[first_value])
+        block.add(first)
+        block.add(second)
+        block.add(ret)
+        program.add_function(function)
+
+        changes = DeadCodeEliminator().optimize(program)
+
+        assert changes == 0
+        assert block.instructions == [first, second, ret]

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -72,11 +72,14 @@ class TestDeadCodeEliminator:
 
         elim = DeadCodeEliminator()
         count = elim.optimize(builder.program)
-        assert count == 1  # the add should be eliminated
+        assert count == 3  # the add and its two dead inputs are eliminated
 
         block = builder.program.functions[0].blocks[0]
         instrs = block.instructions
-        assert all(i.opcode != OpCode.ADD for i in instrs)
+        assert [instr.opcode for instr in instrs] == [
+            OpCode.LOAD_CONST,
+            OpCode.RETURN,
+        ]
 
     def test_keep_used_value(self):
         builder = IRBuilder()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,8 +17,8 @@ class TestConstantFolder:
         r = builder.add(c1, c2)
         builder.ret(r)
 
-        folder = ConstantFolder(builder.program)
-        count = folder.run()
+        folder = ConstantFolder()
+        count = folder.optimize(builder.program)
         assert count == 1
 
         block = builder.program.functions[0].blocks[0]
@@ -36,8 +36,8 @@ class TestConstantFolder:
         r = builder.mul(c1, c2)
         builder.ret(r)
 
-        folder = ConstantFolder(builder.program)
-        count = folder.run()
+        folder = ConstantFolder()
+        count = folder.optimize(builder.program)
         assert count == 1
         # The mul (index 2) was replaced by load_const 10.0
         block = builder.program.functions[0].blocks[0]
@@ -53,8 +53,8 @@ class TestConstantFolder:
         r = builder.add(a, c)
         builder.ret(r)
 
-        folder = ConstantFolder(builder.program)
-        count = folder.run()
+        folder = ConstantFolder()
+        count = folder.optimize(builder.program)
         assert count == 0  # cannot fold because 'a' is not constant
 
 
@@ -70,8 +70,8 @@ class TestDeadCodeEliminator:
         d = builder.load_const(3.0)
         builder.ret(d)
 
-        elim = DeadCodeEliminator(builder.program)
-        count = elim.run()
+        elim = DeadCodeEliminator()
+        count = elim.optimize(builder.program)
         assert count == 1  # the add should be eliminated
 
         block = builder.program.functions[0].blocks[0]
@@ -88,6 +88,6 @@ class TestDeadCodeEliminator:
         c = builder.add(a, b)  # used by ret
         builder.ret(c)
 
-        elim = DeadCodeEliminator(builder.program)
-        count = elim.run()
+        elim = DeadCodeEliminator()
+        count = elim.optimize(builder.program)
         assert count == 0  # nothing eliminated

--- a/tests/test_optimizer_advanced.py
+++ b/tests/test_optimizer_advanced.py
@@ -19,8 +19,8 @@ class TestIRPeepholeOptimizer:
         builder._emit(OpCode.ADD, c, [a, zero])
         builder.ret(c)
 
-        opt = IRPeepholeOptimizer(builder.program)
-        opt.run()
+        opt = IRPeepholeOptimizer()
+        opt.optimize(builder.program)
         # The addi 0 should have been removed
         block = builder.program.functions[0].blocks[0]
         assert all(i.opcode != OpCode.ADD for i in block.instructions)
@@ -35,8 +35,8 @@ class TestIRPeepholeOptimizer:
         builder._emit(OpCode.MUL, c, [a, one])
         builder.ret(c)
 
-        opt = IRPeepholeOptimizer(builder.program)
-        count = opt.run()
+        opt = IRPeepholeOptimizer()
+        count = opt.optimize(builder.program)
         assert count >= 1
         # MUL with 1 should be replaced
         block = builder.program.functions[0].blocks[0]
@@ -53,8 +53,8 @@ class TestIRPeepholeOptimizer:
         builder._emit(OpCode.MUL, c, [a, zero])
         builder.ret(c)
 
-        opt = IRPeepholeOptimizer(builder.program)
-        opt.run()
+        opt = IRPeepholeOptimizer()
+        opt.optimize(builder.program)
         block = builder.program.functions[0].blocks[0]
         mul_instrs = [i for i in block.instructions if i.opcode == OpCode.MUL]
         assert len(mul_instrs) == 0
@@ -77,8 +77,8 @@ class TestMulAddFusion:
         result = builder.add(tmp, acc)
         builder.ret(result)
 
-        opt = MulAddFusion(builder.program)
-        count = opt.run()
+        opt = MulAddFusion()
+        count = opt.optimize(builder.program)
         assert count == 1
 
         block = builder.program.functions[0].blocks[0]
@@ -97,8 +97,8 @@ class TestMulAddFusion:
         c = builder.add(a, b)
         builder.ret(c)
 
-        opt = MulAddFusion(builder.program)
-        count = opt.run()
+        opt = MulAddFusion()
+        count = opt.optimize(builder.program)
         assert count == 0
 
 
@@ -119,8 +119,8 @@ class TestLICM:
         builder.endfor()
         builder.ret()
 
-        opt = LICM(builder.program)
-        count = opt.run()
+        opt = LICM()
+        count = opt.optimize(builder.program)
         assert count == 1  # mul should be hoisted
 
         block = builder.program.functions[0].blocks[0]
@@ -142,8 +142,8 @@ class TestLICM:
         builder.endfor()
         builder.ret()
 
-        opt = LICM(builder.program)
-        opt.run()
+        opt = LICM()
+        opt.optimize(builder.program)
         # The load_const IS invariant and gets hoisted.
         # But the add depending on iv stays in the loop.
         # Verify the add remains after the FOR.

--- a/tests/test_pass_manager.py
+++ b/tests/test_pass_manager.py
@@ -1,0 +1,289 @@
+"""Tests for the unified IR optimization pass framework."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import scratchv.compiler as compiler_module
+from scratchv.compiler import (
+    CompilerConfig,
+    CompilerDriver,
+    PassManager,
+    create_optimization_pass_manager,
+)
+from scratchv.ir.types import Program
+from scratchv.main import args_to_config, build_arg_parser
+from scratchv.optimizer import (
+    ConstantFolder,
+    DeadCodeEliminator,
+    IRPeepholeOptimizer,
+    LICM,
+    MulAddFusion,
+)
+from scratchv.pass_interface import (
+    OptimizationPass,
+    OptimizationPassError,
+    OptimizationReport,
+    PassExecutionStats,
+)
+
+
+class _RecordingPass(OptimizationPass):
+    """Small public-contract fake used by PassManager tests."""
+
+    def __init__(
+        self,
+        name: str,
+        changes: int = 0,
+        calls: list[str] | None = None,
+    ):
+        self._name = name
+        self._changes = changes
+        self._calls = calls
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def optimize(self, program: Program) -> int:
+        if self._calls is not None:
+            self._calls.append(self.name)
+        return self._changes
+
+
+class TestOptimizationPass:
+    def test_base_class_is_abstract(self):
+        with pytest.raises(TypeError):
+            OptimizationPass()
+
+    @pytest.mark.parametrize("name", ["", "   ", None, 7])
+    def test_register_rejects_invalid_name(self, name):
+        manager = PassManager()
+
+        with pytest.raises((TypeError, ValueError)):
+            manager.register(_RecordingPass(name))
+
+    @pytest.mark.parametrize(
+        "pass_type",
+        [
+            ConstantFolder,
+            DeadCodeEliminator,
+            IRPeepholeOptimizer,
+            MulAddFusion,
+            LICM,
+        ],
+    )
+    def test_production_passes_share_the_interface_and_local_counts(
+        self, pass_type
+    ):
+        pass_ = pass_type()
+        program = Program()
+
+        assert isinstance(pass_, OptimizationPass)
+        assert pass_.name
+        assert pass_.optimize(program) == 0
+        assert pass_.optimize(program) == 0
+
+
+class TestPassManager:
+    def test_runs_in_registration_order_and_reports_each_execution(self):
+        calls: list[str] = []
+        program = Program()
+        manager = PassManager("ordered")
+        manager.register(_RecordingPass("first", 2, calls))
+        manager.add(_RecordingPass("second", 3, calls))
+
+        report = manager.run(program)
+
+        assert calls == ["first", "second"]
+        assert report.pipeline_name == "ordered"
+        assert report.total_changes == 5
+        assert report.elapsed_seconds >= 0
+        assert [execution.index for execution in report.executions] == [0, 1]
+        assert [execution.name for execution in report.executions] == [
+            "first",
+            "second",
+        ]
+        assert [execution.changes for execution in report.executions] == [2, 3]
+        assert all(
+            execution.elapsed_seconds >= 0 for execution in report.executions
+        )
+
+    def test_allows_duplicate_pass_names(self):
+        manager = PassManager()
+        manager.register(_RecordingPass("repeat", 1))
+        manager.register(_RecordingPass("repeat", 2))
+
+        report = manager.run(Program())
+
+        assert [(item.index, item.name) for item in report.executions] == [
+            (0, "repeat"),
+            (1, "repeat"),
+        ]
+        assert report.total_changes == 3
+
+    def test_empty_pipeline_returns_an_empty_report(self):
+        report = PassManager("empty").run(Program())
+
+        assert report == OptimizationReport("empty", (), 0, 0.0)
+
+    def test_reports_are_immutable(self):
+        execution = PassExecutionStats(0, "pass", 0, 0.0)
+
+        with pytest.raises(FrozenInstanceError):
+            execution.changes = 1
+
+    @pytest.mark.parametrize("result", [-1, True, 1.5, "1", None])
+    def test_rejects_invalid_change_counts(self, result):
+        manager = PassManager().register(_RecordingPass("invalid", result))
+
+        with pytest.raises(OptimizationPassError) as caught:
+            manager.run(Program())
+
+        assert caught.value.pass_index == 0
+        assert caught.value.pass_name == "invalid"
+        assert caught.value.completed_report.executions == ()
+        assert caught.value.__cause__ is caught.value.cause
+
+    def test_wraps_failure_and_stops_before_later_passes(self):
+        calls: list[str] = []
+
+        class _FailingPass(_RecordingPass):
+            def optimize(self, program: Program) -> int:
+                calls.append(self.name)
+                raise RuntimeError("boom")
+
+        manager = PassManager("failure")
+        manager.register(_RecordingPass("done", 4, calls))
+        manager.register(_FailingPass("broken"))
+        manager.register(_RecordingPass("never", 1, calls))
+
+        with pytest.raises(OptimizationPassError) as caught:
+            manager.run(Program())
+
+        error = caught.value
+        assert calls == ["done", "broken"]
+        assert error.pass_index == 1
+        assert error.pass_name == "broken"
+        assert error.elapsed_seconds >= 0
+        assert error.completed_report.total_changes == 4
+        assert [item.name for item in error.completed_report.executions] == ["done"]
+        assert isinstance(error.cause, RuntimeError)
+        assert error.__cause__ is error.cause
+
+    def test_rejects_non_program_before_running_passes(self):
+        calls: list[str] = []
+        manager = PassManager().register(_RecordingPass("pass", calls=calls))
+
+        with pytest.raises(TypeError):
+            manager.run(object())
+
+        assert calls == []
+
+    def test_does_not_catch_keyboard_interrupt(self):
+        class _InterruptingPass(_RecordingPass):
+            def optimize(self, program: Program) -> int:
+                raise KeyboardInterrupt
+
+        manager = PassManager().register(_InterruptingPass("interrupt"))
+
+        with pytest.raises(KeyboardInterrupt):
+            manager.run(Program())
+
+
+class TestOptimizationLevels:
+    @pytest.mark.parametrize(
+        ("level", "names"),
+        [
+            ("none", []),
+            ("basic", ["constant-folding", "dead-code-elim"]),
+            (
+                "all",
+                [
+                    "constant-folding",
+                    "dead-code-elim",
+                    "ir-peephole",
+                    "muladd-fusion",
+                    "licm",
+                ],
+            ),
+        ],
+    )
+    def test_factory_builds_the_documented_pipeline(self, level, names):
+        manager = create_optimization_pass_manager(level)
+
+        assert [pass_.name for pass_ in manager.passes] == names
+
+    @pytest.mark.parametrize("level", ["", "Basic", "fast", None, 1])
+    def test_factory_rejects_unknown_level(self, level):
+        with pytest.raises((TypeError, ValueError)):
+            create_optimization_pass_manager(level)
+
+
+class TestOptimizationCli:
+    @pytest.mark.parametrize("flag", ["--opt-level", "--optimize"])
+    @pytest.mark.parametrize("level", ["none", "basic", "all"])
+    def test_accepts_canonical_and_compatibility_flags(self, flag, level):
+        args = build_arg_parser().parse_args(["model.onnx", flag, level])
+
+        assert args.optimize_level == level
+        assert args_to_config(args).optimize_level == level
+
+    def test_defaults_to_none(self):
+        args = build_arg_parser().parse_args(["model.onnx"])
+
+        assert args.optimize_level == "none"
+
+
+class _ProgramDriver(CompilerDriver):
+    """Compiler driver test seam that avoids parser and backend dependencies."""
+
+    def __init__(self, config: CompilerConfig):
+        super().__init__(config)
+        self.codegen_called = False
+
+    def _parse(self, input_path: str, dsl_source: str | None = None) -> Program:
+        return Program()
+
+    def _generate_code(self, program: Program) -> str:
+        self.codegen_called = True
+        return "generated"
+
+
+class TestCompilerOptimizationIntegration:
+    def test_exposes_structured_optimization_stats(self, tmp_path):
+        output_path = tmp_path / "output.s"
+        driver = _ProgramDriver(CompilerConfig(optimize_level="basic"))
+
+        result = driver.compile("input.dsl", str(output_path))
+
+        assert result.success
+        assert result.stats["optimization"]["level"] == "basic"
+        assert result.stats["optimization"]["total_changes"] == 0
+        assert [
+            item["name"] for item in result.stats["optimization"]["passes"]
+        ] == ["constant-folding", "dead-code-elim"]
+        assert result.stats["opt_message"]
+
+    def test_pass_failure_stops_codegen_and_output(self, monkeypatch, tmp_path):
+        class _FailingPass(_RecordingPass):
+            def optimize(self, program: Program) -> int:
+                raise RuntimeError("optimizer failed")
+
+        manager = PassManager("optimizer").register(_FailingPass("broken"))
+        monkeypatch.setattr(
+            compiler_module,
+            "create_optimization_pass_manager",
+            lambda level: manager,
+        )
+        output_path = tmp_path / "must-not-exist.s"
+        driver = _ProgramDriver(CompilerConfig(optimize_level="all"))
+
+        result = driver.compile("input.dsl", str(output_path))
+
+        assert not result.success
+        assert "broken" in result.errors[0]
+        assert not driver.codegen_called
+        assert not output_path.exists()

--- a/tests/test_pass_manager.py
+++ b/tests/test_pass_manager.py
@@ -236,6 +236,11 @@ class TestOptimizationCli:
 
         assert args.optimize_level == "none"
 
+    @pytest.mark.parametrize("flag", ["--opt-level", "--optimize"])
+    def test_rejects_unknown_level(self, flag):
+        with pytest.raises(SystemExit):
+            build_arg_parser().parse_args(["model.onnx", flag, "fast"])
+
 
 class _ProgramDriver(CompilerDriver):
     """Compiler driver test seam that avoids parser and backend dependencies."""
@@ -266,6 +271,42 @@ class TestCompilerOptimizationIntegration:
             item["name"] for item in result.stats["optimization"]["passes"]
         ] == ["constant-folding", "dead-code-elim"]
         assert result.stats["opt_message"]
+
+    def test_invalid_driver_level_stops_before_codegen_and_output(self, tmp_path):
+        output_path = tmp_path / "must-not-exist.s"
+        driver = _ProgramDriver(CompilerConfig(optimize_level="fast"))
+
+        result = driver.compile("input.dsl", str(output_path))
+
+        assert not result.success
+        assert "optimization level" in result.errors[0]
+        assert not driver.codegen_called
+        assert not output_path.exists()
+
+    @pytest.mark.parametrize("level", ["none", "basic", "all"])
+    def test_driver_and_benchmark_use_the_same_factory(
+        self, monkeypatch, level
+    ):
+        from benchmarks.run_benchmark import _optimize
+
+        requested_levels: list[str] = []
+        real_factory = compiler_module.create_optimization_pass_manager
+
+        def recording_factory(requested_level: str) -> PassManager:
+            requested_levels.append(requested_level)
+            return real_factory(requested_level)
+
+        monkeypatch.setattr(
+            compiler_module,
+            "create_optimization_pass_manager",
+            recording_factory,
+        )
+        driver = _ProgramDriver(CompilerConfig(optimize_level=level))
+
+        driver._run_optimizations(Program())
+        _optimize(Program(), level)
+
+        assert requested_levels == [level, level]
 
     def test_pass_failure_stops_codegen_and_output(self, monkeypatch, tmp_path):
         class _FailingPass(_RecordingPass):

--- a/tests/test_pass_manager.py
+++ b/tests/test_pass_manager.py
@@ -13,6 +13,7 @@ from scratchv.compiler import (
     PassManager,
     create_optimization_pass_manager,
 )
+from scratchv.ir.builder import IRBuilder
 from scratchv.ir.types import Program
 from scratchv.main import args_to_config, build_arg_parser
 from scratchv.optimizer import (
@@ -220,6 +221,30 @@ class TestOptimizationLevels:
     def test_factory_rejects_unknown_level(self, level):
         with pytest.raises((TypeError, ValueError)):
             create_optimization_pass_manager(level)
+
+    def test_none_pipeline_is_noop_with_zero_elapsed_time(self):
+        from benchmarks.run_benchmark import _optimize
+
+        builder = IRBuilder()
+        builder.new_function("test")
+        block = builder.new_block("entry")
+        result = builder.add(
+            builder.make_value(name="lhs"),
+            builder.make_value(name="rhs"),
+        )
+        builder.ret(result)
+        instructions_before = tuple(block.instructions)
+
+        report = create_optimization_pass_manager("none").run(builder.program)
+
+        assert report == OptimizationReport("optimizer", (), 0, 0.0)
+        assert tuple(block.instructions) == instructions_before
+        assert tuple(map(id, block.instructions)) == tuple(
+            map(id, instructions_before)
+        )
+
+        assert _optimize(builder.program, "none") == 0.0
+        assert tuple(block.instructions) == instructions_before
 
 
 class TestOptimizationCli:

--- a/tests/test_pass_manager.py
+++ b/tests/test_pass_manager.py
@@ -246,6 +246,30 @@ class TestOptimizationLevels:
         assert _optimize(builder.program, "none") == 0.0
         assert tuple(block.instructions) == instructions_before
 
+    def test_basic_pipeline_reports_current_dce_changes(self):
+        builder = IRBuilder()
+        builder.new_function("test")
+        builder.new_block("entry")
+        builder.add(
+            builder.make_value(name="dead_lhs"),
+            builder.make_value(name="dead_rhs"),
+        )
+        live = builder.load_const(1.0)
+        builder.ret(live)
+        manager = create_optimization_pass_manager("basic")
+
+        first_report = manager.run(builder.program)
+        second_report = manager.run(builder.program)
+
+        assert [
+            (execution.name, execution.changes)
+            for execution in first_report.executions
+        ] == [("constant-folding", 0), ("dead-code-elim", 1)]
+        assert [
+            (execution.name, execution.changes)
+            for execution in second_report.executions
+        ] == [("constant-folding", 0), ("dead-code-elim", 0)]
+
 
 class TestOptimizationCli:
     @pytest.mark.parametrize("flag", ["--opt-level", "--optimize"])


### PR DESCRIPTION
## 内容

- 将 `DeadCodeEliminator` 改为单基本块 use-def mark-and-sweep：建立 `dest.name → Instruction` 定义索引，从可观察根递归回溯生产者，再稳定顺序 sweep。
- 保留 `STORE`、`RETURN`、`BR`、`BR_IF`、`FOR`、`ENDFOR`、`ALLOCA` 及所有 dest-less 指令，并完整保留其 operand 依赖链。
- 使用 instruction identity 作为递归访问保护，支持外部/隐式输入叶子和畸形环终止，不修改 IR 数据模型。
- 多基本块函数、重复 SSA 定义和非空 `phi_nodes` 在 W5 保守 no-op，避免提前进行不安全的跨块删除。
- 删除计数覆盖整条死依赖链且只统计本次调用；同一实例或同一 PassManager 重复运行不会累计历史值。
- 新增独立 DCE 行为矩阵、PassManager 集成测试，并同步课题文档与优化指南。

## 范围

本 PR 基于并依赖 #48（W2 统一 Pass 接口与 PassManager）。本分支直接从 W2 基线创建，不依赖 #50 的 W3 ConstantFolder 内容。

本 PR 仅实现课题 4 的 W5「DCE use-def 回溯」。没有实现 W6 的跨基本块分析、CFG 数据流或不动点迭代，也没有修改 `Value`/`Instruction`、IRBuilder、前端、后端、PassManager 配置或其他优化算法。

## 验证

- W5 DCE 行为矩阵：22 passed
- DCE、optimizer 与 PassManager 专项：72 passed
- 可运行完整回归：435 passed, 4 skipped, 3 deselected
- 未筛选完整测试仅保留 3 个既有 Windows 临时文件句柄/TinyFive 环境失败
- Python 语法编译与 `git diff --check` 通过
- 本地环境未安装 Black、isort、Ruff、mypy，未将这些检查写为已通过
- 已对照 W5 设计自审，确认未提前实现 W6

> 草稿 PR，等待维护者先确认 #48 的 W2 接口，再审查 W5 的单块安全边界、effect roots 与删除计数语义。